### PR TITLE
Immutable schema specifications

### DIFF
--- a/src/ORM.js
+++ b/src/ORM.js
@@ -171,7 +171,10 @@ export class ORM {
                 if (!isReservedTableOption(key)) return;
                 throw new Error(`Reserved keyword \`${key}\` used in ${tableName}.options.`);
             });
-            spec[tableName] = Object.assign({}, { fields: modelClass.fields }, tableSpec);
+            spec[tableName] = {
+                fields: { ...modelClass.fields },
+                ...tableSpec,
+            };
             return spec;
         }, {});
         return { tables };

--- a/src/test/unit/ORM.js
+++ b/src/test/unit/ORM.js
@@ -263,6 +263,15 @@ describe('ORM', () => {
             });
         });
 
+        it('immutably adapts schema spec to new model fields', () => {
+            orm.register(Book, Author, Cover, Genre, Tag, Publisher);
+            const coverFields = orm.generateSchemaSpec().tables.Cover.fields;
+            Cover.fields.tag = fk('Tag', 'covers');
+            expect(
+                orm.generateSchemaSpec().tables.Cover.fields
+            ).not.toEqual(coverFields);
+        });
+
         it('correctly starts a mutating session', () => {
             orm.register(Book, Author, Cover, Genre, Tag, Publisher);
             const initialState = orm.getEmptyState();


### PR DESCRIPTION
Ensures that fields (and table options) are shallowly copied instead of directly returning references to the model classes' properties.

~~Has no real effect other than making the result more predictable, in a sense, by enabling a shallow comparison of the fields object.~~ The real effect of this still has to be determined.