### PR TITLE
Selector API improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12630,6 +12630,11 @@
         }
       }
     },
+    "re-reselect": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/re-reselect/-/re-reselect-3.1.0.tgz",
+      "integrity": "sha512-1Dh/EKWarO/SeXZCodZBT2puHZRuZUCngCueisCfggCIg+yldyk/N1PTpCkJW+jiWJX4qJFc6ip5l8wDBRsyaQ=="
+    },
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@babel/runtime": "^7.0.0",
     "immutable-ops": "^0.7.0",
     "lodash": "^4.17.11",
+    "re-reselect": "^3.1.0",
     "reselect": "^3.0.1"
   }
 }

--- a/src/ORM.js
+++ b/src/ORM.js
@@ -53,6 +53,7 @@ export class ORM {
         this.registry = [];
         this.implicitThroughModels = [];
         this.installedFields = {};
+        this.stateSelector = opts ? opts.stateSelector : null;
     }
 
     /**

--- a/src/ORM.js
+++ b/src/ORM.js
@@ -76,7 +76,9 @@ export class ORM {
 
             Object.defineProperty(this, model.modelName, {
                 get: () => {
+                    // make sure virtualFields are set up
                     this._setupModelPrototypes(this.registry);
+
                     return createModelSelectorSpec({
                         model,
                         orm: this,

--- a/src/ORM.js
+++ b/src/ORM.js
@@ -7,10 +7,7 @@ import {
     attr,
 } from './fields';
 
-import {
-    createReducer,
-    createSelector,
-} from './redux';
+import { createModelSelectorSpec } from './selectors';
 
 import {
     m2mName,
@@ -76,6 +73,11 @@ export class ORM {
 
             this.registerManyToManyModelsFor(model);
             this.registry.push(model);
+
+            this[model.modelName] = createModelSelectorSpec({
+                model,
+                orm: this,
+            });
         });
     }
 
@@ -167,9 +169,8 @@ export class ORM {
         const models = this.getModelClasses();
         const tables = models.reduce((spec, modelClass) => {
             const tableName = modelClass.modelName;
-            const tableSpec = modelClass.tableOptions();
-            Object.keys(tableSpec).forEach((key) => {
-                if (!isReservedTableOption(key)) return;
+            const tableSpec = modelClass.tableOptions(); // eslint-disable-line no-underscore-dangle
+            Object.keys(tableSpec).filter(isReservedTableOption).forEach((key) => {
                 throw new Error(`Reserved keyword \`${key}\` used in ${tableName}.options.`);
             });
             spec[tableName] = {
@@ -290,28 +291,6 @@ export class ORM {
             'Use `ORM.prototype.session` instead.'
         );
         return this.session(state);
-    }
-
-    /**
-     * @deprecated Access {@link Session#state} instead.
-     */
-    reducer() {
-        warnDeprecated(
-            '`ORM.prototype.reducer` has been deprecated. Access ' +
-            'the `Session.prototype.state` property instead.'
-        );
-        return createReducer(this);
-    }
-
-    /**
-     * @deprecated Use `import { createSelector } from "redux-orm"` instead.
-     */
-    createSelector(...args) {
-        warnDeprecated(
-            '`ORM.prototype.createSelector` has been deprecated. ' +
-            'Import `createSelector` from Redux-ORM instead.'
-        );
-        return createSelector(this, ...args);
     }
 
     /**

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,3 +8,6 @@ export const ORDER_BY = 'REDUX_ORM_ORDER_BY';
 
 export const SUCCESS = 'SUCCESS';
 export const FAILURE = 'FAILURE';
+
+export const STATE_FLAG_KEY = '@@_______REDUX_ORM_STATE';
+export const STATE_FLAG_VALUE = Symbol('REDUX_ORM_STATE');

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,5 +9,4 @@ export const ORDER_BY = 'REDUX_ORM_ORDER_BY';
 export const SUCCESS = 'SUCCESS';
 export const FAILURE = 'FAILURE';
 
-export const STATE_FLAG_KEY = '@@_______REDUX_ORM_STATE';
-export const STATE_FLAG_VALUE = Symbol('REDUX_ORM_STATE');
+export const STATE_FLAG = Symbol('REDUX_ORM_STATE_FLAG');

--- a/src/db/Database.js
+++ b/src/db/Database.js
@@ -2,10 +2,16 @@ import ops from 'immutable-ops';
 
 import {
     CREATE, UPDATE, DELETE, SUCCESS,
+    STATE_FLAG_KEY, STATE_FLAG_VALUE,
 } from '../constants';
 
 import Table from './Table';
 
+const BASE_EMPTY_STATE = {};
+Object.defineProperty(BASE_EMPTY_STATE, STATE_FLAG_KEY, {
+    enumerable: true,
+    value: STATE_FLAG_VALUE,
+});
 
 function replaceTableState(tableName, newTableState, tx, state) {
     const { batchToken, withMutations } = tx;
@@ -84,7 +90,7 @@ export function createDatabase(schemaSpec) {
             .reduce((map, [tableName, table]) => ({
                 ...map,
                 [tableName]: table.getEmptyState(),
-            }), {})
+            }), BASE_EMPTY_STATE)
     );
 
     return {

--- a/src/db/Database.js
+++ b/src/db/Database.js
@@ -2,15 +2,15 @@ import ops from 'immutable-ops';
 
 import {
     CREATE, UPDATE, DELETE, SUCCESS,
-    STATE_FLAG_KEY, STATE_FLAG_VALUE,
+    STATE_FLAG,
 } from '../constants';
 
 import Table from './Table';
 
 const BASE_EMPTY_STATE = {};
-Object.defineProperty(BASE_EMPTY_STATE, STATE_FLAG_KEY, {
+Object.defineProperty(BASE_EMPTY_STATE, STATE_FLAG, {
     enumerable: true,
-    value: STATE_FLAG_VALUE,
+    value: STATE_FLAG,
 });
 
 function replaceTableState(tableName, newTableState, tx, state) {

--- a/src/fields.js
+++ b/src/fields.js
@@ -227,7 +227,7 @@ export class Attribute extends Field {
 /**
  * @ignore
  */
-class RelationalField extends Field {
+export class RelationalField extends Field {
     constructor(...args) {
         super();
         if (args.length === 1 && typeof args[0] === 'object') {

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -168,8 +168,9 @@ export function memoize(func, argEqualityCheck = defaultEqualityCheck, orm) {
          * the operations that the selector performs are cacheable.
          */
         const session = orm.session(ormState);
-
+        /* Replace all ORM state arguments by the session above */
         const argsWithSession = args.map(arg => (isOrmState(arg) ? session : arg));
+
         /* This is where we call the actual function */
         const result = func(...argsWithSession);
 

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -1,4 +1,4 @@
-import { STATE_FLAG_KEY } from './constants';
+import { STATE_FLAG } from './constants';
 
 const defaultEqualityCheck = (a, b) => a === b;
 export const eqCheck = defaultEqualityCheck;
@@ -6,7 +6,7 @@ export const eqCheck = defaultEqualityCheck;
 const isOrmState = arg => (
     arg &&
     typeof arg === 'object' &&
-    arg.hasOwnProperty(STATE_FLAG_KEY)
+    arg.hasOwnProperty(STATE_FLAG)
 );
 
 const argsAreEqual = (lastArgs, nextArgs, equalityCheck) => (

--- a/src/memoize.js
+++ b/src/memoize.js
@@ -169,8 +169,7 @@ export function memoize(func, argEqualityCheck = defaultEqualityCheck, orm) {
          */
         const session = orm.session(ormState);
 
-        const argsWithSession = args.map(arg => (isOrmState(arg) ? session : arg)
-        );
+        const argsWithSession = args.map(arg => (isOrmState(arg) ? session : arg));
         /* This is where we call the actual function */
         const result = func(...argsWithSession);
 

--- a/src/redux.js
+++ b/src/redux.js
@@ -115,11 +115,11 @@ export function createSelector(...args) {
 
     const resultArg = args.pop();
     const dependencies = Array.isArray(args[0]) ? args[0] : args;
-    const orm = dependencies.find((arg) => { /* eslint-disable no-underscore-dangle */
+    const orm = dependencies.map((arg) => { /* eslint-disable no-underscore-dangle */
         if (arg instanceof ORM) return arg;
         if (arg instanceof SelectorSpec) return arg._orm;
-        return null;
-    });
+        return false;
+    }).find(Boolean);
     const argToSelector = (arg) => { /* eslint-disable no-underscore-dangle */
         if (arg instanceof ORM) return arg.stateSelector;
         if (arg instanceof SelectorSpec) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -6,6 +6,7 @@ import { memoize } from './memoize';
 import { ORM } from './ORM';
 import {
     SelectorSpec,
+    MapSelectorSpec,
 } from './selectors';
 
 /**
@@ -72,6 +73,9 @@ function toSelector(arg) { /* eslint-disable no-underscore-dangle */
     }
     if (arg instanceof ORM) {
         return arg.stateSelector;
+    }
+    if (arg instanceof MapSelectorSpec) {
+        arg._selector = toSelector(arg._selector);
     }
     if (arg instanceof SelectorSpec) {
         const { _orm: orm, cachePath } = arg;

--- a/src/redux.js
+++ b/src/redux.js
@@ -75,7 +75,8 @@ function toSelector(arg) { /* eslint-disable no-underscore-dangle */
     }
     if (arg instanceof SelectorSpec) {
         const { _orm: orm, cachePath } = arg;
-        let ormSelectors, level;
+        let ormSelectors;
+        let level;
         if (cachePath && cachePath.length) {
             // the selector cache for the spec's ORM
             if (!selectorCache.has(orm)) {

--- a/src/redux.js
+++ b/src/redux.js
@@ -83,11 +83,11 @@ function toSelector(arg) { /* eslint-disable no-underscore-dangle */
             ormSelectors = selectorCache.get(orm) || {};
 
             /**
-            * Drill down into selector map object by cachePath.
-            *
-            * The selector itself is stored under a special SELECTOR_KEY
-            * so that we can store selectors below it as well.
-            */
+             * Drill down into selector map object by cachePath.
+             *
+             * The selector itself is stored under a special SELECTOR_KEY
+             * so that we can store selectors below it as well.
+             */
             let level = ormSelectors;
             for (let i = 0; i < cachePath.length; ++i) {
                 if (!level) break;

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,0 +1,98 @@
+/**
+ * @module selectors
+ */
+
+const ALL_INSTANCES = Symbol('REDUX_ORM_ALL_INSTANCES');
+
+function idArgSelector(state, idArg) {
+    return idArg;
+}
+
+export class SelectorSpec {
+    constructor({ parent, orm }) {
+        this._parent = parent;
+        this._orm = orm;
+    }
+}
+
+export class ModelSelectorSpec extends SelectorSpec {
+    constructor({ model, ...other }) {
+        super(other);
+        this._model = model;
+    }
+
+    get dependencies() {
+        return [this._orm, idArgSelector];
+    }
+
+    get resultFunc() {
+        return ({ [this._model.modelName]: ModelClass }, idArg) => {
+            if (typeof idArg === 'undefined') {
+                return ModelClass.all().toRefArray();
+            }
+            if (Array.isArray(idArg)) {
+                const { idAttribute } = ModelClass;
+                /**
+                    * TODO: we might want to allow passing arrays of property values
+                    * for faster matching of indexed columns; this might be the
+                    * key to allowing fast joins anyways, and could potentially
+                    * be re-used for any type of indexed value lookup */
+                return ModelClass
+                    .filter(instance => idArg.includes(instance[idAttribute]))
+                    .toRefArray();
+            }
+            const instance = ModelClass.withId(idArg);
+            return instance ? instance.ref : null;
+        };
+    }
+
+    get keySelector() {
+        return (state, idArg) => (
+            (typeof idArg === 'undefined') ? ALL_INSTANCES : idArg
+        );
+    }
+
+    get key() {
+        return this._model.modelName;
+    }
+}
+
+export class FieldSelectorSpec extends SelectorSpec {
+    constructor({
+        model, field, fieldName, ...other
+    }) {
+        super(other);
+        this._model = model;
+        this._field = field;
+        this._fieldName = fieldName;
+    }
+
+    get key() {
+        return this._fieldName;
+    }
+}
+
+function createFieldSelectorSpec({ modelSelectorSpec, field, orm }) {
+    return new SelectorSpec({
+        parent: modelSelectorSpec,
+        orm,
+        field,
+    });
+}
+
+export function createModelSelectorSpec({ model, orm }) {
+    const modelSelectorSpec = new ModelSelectorSpec({
+        parent: null,
+        orm,
+        model,
+    });
+    Object.entries(model.fields).forEach(([fieldName, field]) => {
+        modelSelectorSpec[fieldName] = createFieldSelectorSpec({
+            parent: modelSelectorSpec,
+            field,
+            fieldName,
+            orm,
+        });
+    });
+    return modelSelectorSpec;
+}

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -155,22 +155,24 @@ export function createModelSelectorSpec({ model, orm }) {
     });
 
     Object.entries(model.fields).forEach(([fieldName, field]) => {
-        modelSelectorSpec[field.as || fieldName] = createFieldSelectorSpec({
+        const accessorName = field.as || fieldName;
+        modelSelectorSpec[accessorName] = createFieldSelectorSpec({
             modelSelectorSpec,
             model,
             field,
-            fieldName: field.as || fieldName,
+            fieldName: accessorName,
             orm,
         });
     });
 
     Object.entries(model.virtualFields).forEach(([fieldName, field]) => {
-        if (modelSelectorSpec[fieldName]) return;
-        modelSelectorSpec[field.as || fieldName] = createFieldSelectorSpec({
+        const accessorName = field.as || fieldName;
+        if (modelSelectorSpec[accessorName]) return;
+        modelSelectorSpec[accessorName] = createFieldSelectorSpec({
             modelSelectorSpec,
             model,
             field,
-            fieldName: field.as || fieldName,
+            fieldName: accessorName,
             orm,
         });
     });

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -79,8 +79,8 @@ export class MapSelectorSpec extends SelectorSpec {
         this._selector = selector;
     }
 
-    get cachePath() {
-        return null;
+    get key() {
+        return this._selector;
     }
 
     get dependencies() {

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -181,7 +181,7 @@ export class FieldSelectorSpec extends ModelBasedSelectorSpec {
         return value;
     }
 
-    map(selector) {
+    map(selector) { /* eslint-disable no-underscore-dangle */
         if (selector instanceof ModelSelectorSpec) {
             if (this.toModelName === selector._model.modelName) {
                 throw new Error(`Cannot select models in a \`map()\` call. If you just want the \`${this._accessorName}\` as a ref array then you can simply drop the \`map()\`. Otherwise make sure you're passing a field selector of the form \`${this.toModelName}.<field>\` or a custom selector instead.`);
@@ -194,7 +194,7 @@ export class FieldSelectorSpec extends ModelBasedSelectorSpec {
             }
         } else if (
             !selector ||
-            typeof selector === 'function' &&
+            typeof selector !== 'function' ||
             !selector.recomputations
         ) {
             throw new Error(`\`map()\` requires a selector as an input. Received: ${JSON.stringify(selector)} of type ${typeof selector}`);

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -182,9 +182,19 @@ export class FieldSelectorSpec extends ModelBasedSelectorSpec {
     }
 
     map(selector) {
-        if (
+        if (selector instanceof ModelSelectorSpec) {
+            if (this.toModelName === selector._model.modelName) {
+                throw new Error(`Cannot select models in a \`map()\` call. If you just want the \`${this._accessorName}\` as a ref array then you can simply drop the \`map()\`. Otherwise make sure you're passing a field selector of the form \`${this.toModelName}.<field>\` or a custom selector instead.`);
+            } else {
+                throw new Error(`Cannot select \`${selector._model.modelName}\` models in this \`map()\` call. Make sure you're passing a field selector of the form \`${this.toModelName}.<field>\` or a custom selector instead.`);
+            }
+        } else if (selector instanceof FieldSelectorSpec) {
+            if (this.toModelName !== selector._model.modelName) {
+                throw new Error(`Cannot select fields of the \`${selector._model.modelName}\` model in this \`map()\` call. Make sure you're passing a field selector of the form \`${this.toModelName}.<field>\` or a custom selector instead.`);
+            }
+        } else if (
             !selector ||
-            typeof selector !== 'function' ||
+            typeof selector === 'function' &&
             !selector.recomputations
         ) {
             throw new Error(`\`map()\` requires a selector as an input. Received: ${JSON.stringify(selector)} of type ${typeof selector}`);

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -189,7 +189,7 @@ export class FieldSelectorSpec extends SelectorSpec {
             return value ? value.ref : null;
         }
         if (this._field instanceof OneToOne) {
-            return value;
+            return value ? value.ref : null;
         }
         if (this._field instanceof ManyToMany) {
             return value.toRefArray();

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -120,16 +120,17 @@ export class MapSelectorSpec extends ModelBasedSelectorSpec {
 
     valueForInstance(instance, session, state) {
         if (!instance) return null;
-        const { [this._accessorName]: value } = instance;
-        const referencedModel = session[this._field.toModelName];
-        const { idAttribute: mapIdAttribute } = referencedModel;
-        if (value instanceof QuerySet) {
-            return value.toRefArray()
-                .map(ref => this._selector(state, ref[mapIdAttribute]));
-        }
-        return value
-            ? this._selector(state, value.ref[mapIdAttribute])
-            : null;
+        const {
+            [this._accessorName]: value,
+        } = instance;
+        if (!value) return null;
+        const {
+            [this._field.toModelName]: {
+                idAttribute: mapIdAttribute,
+            },
+        } = session;
+        return value.toRefArray()
+            .map(ref => this._selector(state, ref[mapIdAttribute]));
     }
 }
 

--- a/src/selectors.js
+++ b/src/selectors.js
@@ -1,5 +1,5 @@
 import {
-    Attribute, OneToOne, ForeignKey, ManyToMany,
+    OneToOne, ForeignKey, ManyToMany,
 } from './fields';
 import QuerySet from './QuerySet';
 
@@ -179,9 +179,6 @@ export class FieldSelectorSpec extends SelectorSpec {
 
     _getFieldValue(instance) {
         const { [this._fieldName]: value } = instance;
-        if (this._field instanceof Attribute) {
-            return value;
-        }
         if (this._field instanceof ForeignKey) {
             if (value instanceof QuerySet) {
                 return value.toRefArray();
@@ -194,7 +191,7 @@ export class FieldSelectorSpec extends SelectorSpec {
         if (this._field instanceof ManyToMany) {
             return value.toRefArray();
         }
-        throw new Error('Could not compute selector result: Unknown field type');
+        return value;
     }
 
     map(selector) {

--- a/src/test/functional/deprecations.js
+++ b/src/test/functional/deprecations.js
@@ -1,5 +1,5 @@
 import {
-    Model, QuerySet, ORM, Backend, Schema, createSelector, createReducer
+    Model, QuerySet, ORM, Backend, Schema,
 } from '../..';
 import { createTestSessionWithData, createTestORM } from '../helpers';
 
@@ -45,53 +45,6 @@ describe('Deprecations', () => {
 
             expect(consoleWarn.timesRun).toBe(1);
             expect(consoleWarn.lastMessage).toBe('`ORM.prototype.from` has been deprecated. Use `ORM.prototype.session` instead.');
-        });
-
-        it('ORM#reducer is deprecated', () => {
-            const { Book } = session;
-            Book.reducer = (action, modelClass, _session) => {
-                if (action.type !== 'CREATE_BOOK') return;
-                modelClass.create(action.payload);
-            };
-            expect(consoleWarn.timesRun).toBe(0);
-            const action = {
-                type: 'CREATE_BOOK',
-                payload: { name: 'New Book' },
-            };
-
-            expect(orm.reducer()(session.state, action))
-                .toEqual(createReducer(orm)(session.state, action));
-
-            expect(consoleWarn.timesRun).toBe(1);
-            expect(consoleWarn.lastMessage).toBe('`ORM.prototype.reducer` has been deprecated. Access the `Session.prototype.state` property instead.');
-        });
-
-        it('ORM#createSelector is deprecated', () => {
-            let selector1TimesRun = 0;
-            let selector2TimesRun = 0;
-            const { Book } = session;
-            const selector1 = createSelector(orm, (memoizeSession) => {
-                selector1TimesRun++;
-                return memoizeSession.Book.withId(0);
-            });
-
-            expect(consoleWarn.timesRun).toBe(0);
-            const selector2 = orm.createSelector((memoizeSession) => {
-                selector2TimesRun++;
-                return memoizeSession.Book.withId(0);
-            });
-            expect(consoleWarn.timesRun).toBe(1);
-            expect(consoleWarn.lastMessage).toBe('`ORM.prototype.createSelector` has been deprecated. Import `createSelector` from Redux-ORM instead.');
-
-            expect(selector1(session.state))
-                .toEqual(selector2(session.state));
-            expect(selector1TimesRun).toEqual(selector2TimesRun);
-
-            Book.withId(0).update({ name: 'Deprecated selector test' });
-
-            expect(selector1(session.state))
-                .toEqual(selector2(session.state));
-            expect(selector1TimesRun).toEqual(selector2TimesRun);
         });
 
         it('ORM#getDefaultState is deprecated', () => {

--- a/src/test/functional/performance.js
+++ b/src/test/functional/performance.js
@@ -65,7 +65,7 @@ describe('Big Data Test', () => {
             });
         }).map(ms => ms / 1000);
 
-        const tookSeconds = round(avg(measurements, n), PRECISION);
+        const tookSeconds = round(avg(measurements), PRECISION);
         logTime(`Creating ${amount} objects`, tookSeconds, maxSeconds, measurements);
         expect(tookSeconds).toBeLessThanOrEqual(maxSeconds);
     });
@@ -95,7 +95,7 @@ describe('Big Data Test', () => {
             });
         }).map(ms => ms / 1000);
 
-        const tookSeconds = round(avg(measurements, n), PRECISION);
+        const tookSeconds = round(avg(measurements), PRECISION);
         logTime(`Looking up ${lookupCount} objects by id`, tookSeconds, maxSeconds, measurements);
         expect(tookSeconds).toBeLessThanOrEqual(maxSeconds);
     });
@@ -127,7 +127,7 @@ describe('Big Data Test', () => {
             })
         )).map(ms => ms / 1000);
 
-        const tookSeconds = round(avg(measurements, n), PRECISION);
+        const tookSeconds = round(avg(measurements), PRECISION);
         logTime(`Looking up ${withForeignKeyCount} objects by foreign key`, tookSeconds, maxSeconds, measurements);
         expect(tookSeconds).toBeLessThanOrEqual(maxSeconds);
     });
@@ -193,7 +193,7 @@ describe('Many-to-many relationship performance', () => {
             return ms;
         }).map(ms => ms / 1000);
 
-        const tookSeconds = round(avg(measurements, n), PRECISION);
+        const tookSeconds = round(avg(measurements), PRECISION);
         logTime(`Adding ${childAmount} m2n relationships`, tookSeconds, maxSeconds, measurements);
         expect(tookSeconds).toBeLessThanOrEqual(maxSeconds);
     });
@@ -216,7 +216,7 @@ describe('Many-to-many relationship performance', () => {
             })
         )).map(ms => ms / 1000);
 
-        const tookSeconds = round(avg(measurements, n), PRECISION);
+        const tookSeconds = round(avg(measurements), PRECISION);
         logTime(`Performing ${queryCount} m2n relationship queries`, tookSeconds, maxSeconds, measurements);
         expect(tookSeconds).toBeLessThanOrEqual(maxSeconds);
     });
@@ -239,7 +239,7 @@ describe('Many-to-many relationship performance', () => {
             return ms;
         }).map(ms => ms / 1000);
 
-        const tookSeconds = round(avg(measurements, n), PRECISION);
+        const tookSeconds = round(avg(measurements), PRECISION);
         logTime(`Removing ${removeCount} m2n relationships`, tookSeconds, maxSeconds, measurements);
         expect(tookSeconds).toBeLessThanOrEqual(maxSeconds);
     });

--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -271,10 +271,10 @@ export function measureMs(fn) {
     return measureMsSince(start);
 }
 
-export const avg = (arr, n) => {
-    if (n === 0) return null;
+export const avg = (arr) => {
+    if (arr.length === 0) return null;
     const sum = arr.reduce((cur, summand) => cur + summand);
-    return sum / n;
+    return sum / arr.length;
 };
 
 export const round = (num, precision, base = 10) => {

--- a/src/test/helpers.js
+++ b/src/test/helpers.js
@@ -272,6 +272,7 @@ export function measureMs(fn) {
 }
 
 export const avg = (arr, n) => {
+    if (n === 0) return null;
     const sum = arr.reduce((cur, summand) => cur + summand);
     return sum / n;
 };

--- a/src/test/integration/selectors.js
+++ b/src/test/integration/selectors.js
@@ -611,7 +611,7 @@ describe('Shorthand selector specifications', () => {
         it('will throw for non foreign key fields', () => {
             expect(() => orm.Publisher.movies.map(null))
                 .toThrow('`map()` requires a selector as an input. Received: null of type object');
-            expect(() => orm.Publisher.movies.map(() => {}))
+            expect(() => orm.Publisher.movies.map(() => null))
                 .toThrow('`map()` requires a selector as an input. Received: undefined of type function');
             expect(() => orm.Author.name.map(createSelector(orm, () => {})))
                 .toThrow('Cannot map selectors for other fields than foreign key fields');

--- a/src/test/integration/selectors.js
+++ b/src/test/integration/selectors.js
@@ -49,77 +49,6 @@ describe('Shorthand selector specifications', () => {
         ormState = emptyState;
     });
 
-    it('will recompute single model instances', () => {
-        const publishers = createSelector(orm.Publisher);
-        expect(publishers(emptyState, 1)).toEqual(null);
-        expect(publishers.recomputations()).toEqual(1);
-        expect(publishers(emptyState, 1)).toEqual(null);
-        expect(publishers.recomputations()).toEqual(1);
-        ormState = reducer(emptyState, {
-            type: CREATE_PUBLISHER,
-            payload: {
-                id: 1,
-            },
-        });
-        expect(publishers(ormState, 1)).toEqual({
-            id: 1,
-        });
-        expect(publishers.recomputations()).toEqual(2);
-    });
-
-    it('will recompute some model instances by ID array', () => {
-        const publishers = createSelector(orm.Publisher);
-        expect(publishers(emptyState, [])).toHaveLength(0);
-        expect(publishers.recomputations()).toEqual(1);
-        expect(publishers(emptyState, [])).toHaveLength(0);
-        expect(publishers.recomputations()).toEqual(2);
-        const zeroAndTwo = [0, 2];
-        expect(publishers(emptyState, zeroAndTwo)).toHaveLength(0);
-        expect(publishers.recomputations()).toEqual(3);
-        expect(publishers(emptyState, zeroAndTwo)).toHaveLength(0);
-        expect(publishers.recomputations()).toEqual(3);
-        ormState = reducer(emptyState, {
-            type: CREATE_PUBLISHER,
-            payload: {
-                id: 1,
-            },
-        });
-        expect(publishers(ormState, zeroAndTwo)).toHaveLength(0);
-        /**
-         * Note that the above only recomputes because we need to
-         * perform a full-table scan there, even if we knew before
-         * exactly which IDs we wanted to access. This should
-         * be fixable by allowing arrays as filter arguments.
-         */
-        expect(publishers.recomputations()).toEqual(4);
-        ormState = reducer(ormState, {
-            type: CREATE_PUBLISHER,
-            payload: {
-                id: 2,
-            },
-        });
-        expect(publishers(ormState, zeroAndTwo)).toHaveLength(1);
-        expect(publishers.recomputations()).toEqual(5);
-        expect(publishers(ormState, zeroAndTwo)).toHaveLength(1);
-        expect(publishers.recomputations()).toEqual(5);
-    });
-
-    it('will recompute all model instances', () => {
-        const publishers = createSelector(orm.Publisher);
-        expect(publishers(emptyState)).toHaveLength(0);
-        expect(publishers.recomputations()).toEqual(1);
-        expect(publishers(emptyState)).toHaveLength(0);
-        expect(publishers.recomputations()).toEqual(1);
-        ormState = reducer(emptyState, {
-            type: CREATE_PUBLISHER,
-            payload: {
-                id: 1,
-            },
-        });
-        expect(publishers(ormState)).toHaveLength(1);
-        expect(publishers.recomputations()).toEqual(2);
-    });
-
     it('throws for invalid arguments', () => {
         expect(() => {
             createSelector();
@@ -144,45 +73,221 @@ describe('Shorthand selector specifications', () => {
         }).toThrow('Failed to interpret selector argument: "a"');
     });
 
-    /*
-    it('will compute related models', () => {
-        // The way we have to do it right now.
-        const old = createSelector(
-            orm,
-            (state, id) => id,
-            ({ Publisher }, id) => (
-                avg(Publisher.withId(id).movies.map(movie => movie.rating))
-            ),
-        );
-        // This is the desired new functionality.
-        const publisherRatingAvg = createSelector(
-            orm.Publisher.movies,
-            (_, movies) => avg(movies.map(movie => movie.rating))
-        );
-        expect(() => publisherRatingAvg(emptyState, 0))
-            .toThrow('Publisher with id 0 doesn\'t exist');
-        ormState = reducer(ormState, {
-            type: CREATE_PUBLISHER,
-            payload: {
-                id: 123,
-            },
+    describe('model selector specs', () => {
+        it('will recompute single model instances', () => {
+            const publishers = createSelector(orm.Publisher);
+            expect(publishers(emptyState, 1)).toEqual(null);
+            expect(publishers.recomputations()).toEqual(1);
+            expect(publishers(emptyState, 1)).toEqual(null);
+            expect(publishers.recomputations()).toEqual(1);
+            ormState = reducer(emptyState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 1,
+                },
+            });
+            expect(publishers(ormState, 1)).toEqual({
+                id: 1,
+            });
+            expect(publishers.recomputations()).toEqual(2);
         });
-        expect(publisherRatingAvg(ormState, 123)).toEqual(null);
-        ormState = reducer(ormState, {
-            type: CREATE_MOVIE,
-            payload: {
-                rating: 6,
-                publisher: 123,
-            },
+
+        it('will recompute some model instances by ID array', () => {
+            const publishers = createSelector(orm.Publisher);
+            expect(publishers(emptyState, [])).toEqual([]);
+            expect(publishers.recomputations()).toEqual(1);
+            expect(publishers(emptyState, [])).toEqual([]);
+            expect(publishers.recomputations()).toEqual(2);
+            const zeroAndTwo = [0, 2];
+            expect(publishers(emptyState, zeroAndTwo)).toEqual([]);
+            expect(publishers.recomputations()).toEqual(3);
+            expect(publishers(emptyState, zeroAndTwo)).toEqual([]);
+            expect(publishers.recomputations()).toEqual(3);
+            ormState = reducer(emptyState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 1,
+                },
+            });
+            expect(publishers(ormState, zeroAndTwo)).toEqual([]);
+            /**
+            * Note that the above only recomputes because we need to
+            * perform a full-table scan there, even if we knew before
+            * exactly which IDs we wanted to access. This should
+            * be fixable by allowing arrays as filter arguments.
+            */
+            expect(publishers.recomputations()).toEqual(4);
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 2,
+                },
+            });
+            expect(publishers(ormState, zeroAndTwo)).toHaveLength(1);
+            expect(publishers.recomputations()).toEqual(5);
+            expect(publishers(ormState, zeroAndTwo)).toHaveLength(1);
+            expect(publishers.recomputations()).toEqual(5);
         });
-        ormState = reducer(ormState, {
-            type: CREATE_MOVIE,
-            payload: {
-                rating: 7,
-                publisher: 123,
-            },
+
+        it('will recompute all model instances', () => {
+            const publishers = createSelector(orm.Publisher);
+            expect(publishers(emptyState)).toEqual([]);
+            expect(publishers.recomputations()).toEqual(1);
+            expect(publishers(emptyState)).toEqual([]);
+            expect(publishers.recomputations()).toEqual(1);
+            ormState = reducer(emptyState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 1,
+                },
+            });
+            expect(publishers(ormState)).toEqual([
+                { id: 1 }
+            ]);
+            expect(publishers.recomputations()).toEqual(2);
         });
-        expect(publisherRatingAvg(ormState, 123)).toEqual(6.5);
     });
-    */
+
+    describe('field selector specs', () => {
+        it('will recompute attr fields for single model instances', () => {
+            const publisherNames = createSelector(orm.Publisher.name);
+            expect(publisherNames(emptyState, 1)).toEqual(null);
+            expect(publisherNames.recomputations()).toEqual(1);
+            expect(publisherNames(emptyState, 1)).toEqual(null);
+            expect(publisherNames.recomputations()).toEqual(1);
+            ormState = reducer(emptyState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 1,
+                    name: 'Publisher name!'
+                },
+            });
+            expect(publisherNames(ormState, 1)).toEqual('Publisher name!');
+            expect(publisherNames.recomputations()).toEqual(2);
+        });
+
+        /*
+        it('will compute related models for single model instances', () => {
+            const publisherMovies = createSelector(orm.Publisher.movies);
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(publisherMovies(ormState, 123)).toEqual([]);
+            ormState = reducer(ormState, {
+                type: CREATE_MOVIE,
+                payload: {
+                    id: 1,
+                    publisher: 123,
+                },
+            });
+            expect(publisherMovies(ormState, 123)).toEqual([
+                { id: 1, publisher: 123 }
+            ]);
+            ormState = reducer(ormState, {
+                type: CREATE_MOVIE,
+                payload: {
+                    id: 2,
+                    publisher: 123,
+                },
+            });
+            expect(publisherMovies(ormState, 123)).toEqual([
+                { id: 1, publisher: 123 },
+                { id: 2, publisher: 123 },
+            ]);
+        });
+        */
+
+        it('will recompute attr fields for some model instances', () => {
+            const publisherNames = createSelector(orm.Publisher.name);
+            expect(publisherNames(emptyState, [])).toEqual([]);
+            expect(publisherNames.recomputations()).toEqual(1);
+            expect(publisherNames(emptyState, [])).toEqual([]);
+            expect(publisherNames.recomputations()).toEqual(2);
+            const zeroAndTwo = [0, 2];
+            expect(publisherNames(emptyState, zeroAndTwo)).toEqual([]);
+            expect(publisherNames.recomputations()).toEqual(3);
+            expect(publisherNames(emptyState, zeroAndTwo)).toEqual([]);
+            expect(publisherNames.recomputations()).toEqual(3);
+            ormState = reducer(emptyState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 1,
+                    name: 'Publisher name!'
+                },
+            });
+            expect(publisherNames(ormState, zeroAndTwo)).toEqual([]);
+            expect(publisherNames.recomputations()).toEqual(4);
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 2,
+                    name: 'Other publisher name!'
+                },
+            });
+            expect(publisherNames(ormState, zeroAndTwo)).toEqual(['Other publisher name!']);
+            expect(publisherNames.recomputations()).toEqual(5);
+        });
+
+        it('will recompute attr fields for all model instances', () => {
+            const publisherNames = createSelector(orm.Publisher.name);
+            expect(publisherNames(emptyState)).toEqual([]);
+            expect(publisherNames.recomputations()).toEqual(1);
+            expect(publisherNames(emptyState)).toEqual([]);
+            expect(publisherNames.recomputations()).toEqual(1);
+            ormState = reducer(emptyState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 1,
+                    name: 'Publisher name!'
+                },
+            });
+            expect(publisherNames(ormState)).toEqual(['Publisher name!']);
+            expect(publisherNames.recomputations()).toEqual(2);
+        });
+
+        /*
+        it('will compute related models', () => {
+            // The way we have to do it right now.
+            const old = createSelector(
+                orm,
+                (state, id) => id,
+                ({ Publisher }, id) => (
+                    avg(Publisher.withId(id).movies.map(movie => movie.rating))
+                ),
+            );
+            // This is the desired new functionality.
+            const publisherRatingAvg = createSelector(
+                orm.Publisher.movies,
+                (_, movies) => avg(movies.map(movie => movie.rating))
+            );
+            expect(() => publisherRatingAvg(emptyState, 0))
+                .toThrow('Publisher with id 0 doesn\'t exist');
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(publisherRatingAvg(ormState, 123)).toEqual(null);
+            ormState = reducer(ormState, {
+                type: CREATE_MOVIE,
+                payload: {
+                    rating: 6,
+                    publisher: 123,
+                },
+            });
+            ormState = reducer(ormState, {
+                type: CREATE_MOVIE,
+                payload: {
+                    rating: 7,
+                    publisher: 123,
+                },
+            });
+            expect(publisherRatingAvg(ormState, 123)).toEqual(6.5);
+        });
+        */
+    });
 });

--- a/src/test/integration/selectors.js
+++ b/src/test/integration/selectors.js
@@ -611,6 +611,10 @@ describe('Shorthand selector specifications', () => {
         it('will throw for non foreign key fields', () => {
             expect(() => orm.Publisher.movies.map(null))
                 .toThrow('`map()` requires a selector as an input. Received: null of type object');
+            expect(() => orm.Publisher.movies.map(() => {}))
+                .toThrow('`map()` requires a selector as an input. Received: undefined of type function');
+            expect(() => orm.Author.name.map(createSelector(orm, () => {})))
+                .toThrow('Cannot map selectors for other fields than foreign key fields');
             const publisherName = createSelector(orm.Publisher.name);
             expect(() => orm.Author.publishers.map(publisherName))
                 .toThrow('Cannot map selectors for other fields than foreign key fields');

--- a/src/test/integration/selectors.js
+++ b/src/test/integration/selectors.js
@@ -341,10 +341,10 @@ describe('Shorthand selector specifications', () => {
                 { id: 1, publisherId: 123 }
             ]);
             expect(publisherMovies(ormState, [123])).toEqual([
-                [ { id: 1, publisherId: 123 } ],
+                [{ id: 1, publisherId: 123 }],
             ]);
             expect(publisherMovies(ormState)).toEqual([
-                [ { id: 1, publisherId: 123 } ],
+                [{ id: 1, publisherId: 123 }],
             ]);
             ormState = reducer(ormState, {
                 type: CREATE_MOVIE,

--- a/src/test/integration/selectors.js
+++ b/src/test/integration/selectors.js
@@ -19,6 +19,9 @@ describe('Shorthand selector specifications', () => {
 
     const CREATE_MOVIE = 'CREATE_MOVIE';
     const CREATE_PUBLISHER = 'CREATE_PUBLISHER';
+    const CREATE_BOOK = 'CREATE_BOOK';
+    const CREATE_COVER = 'CREATE_COVER';
+    const CREATE_AUTHOR = 'CREATE_AUTHOR';
 
     const consoleWarn = jest.spyOn(global.console, 'warn')
         .mockImplementation(msg => msg);
@@ -43,6 +46,15 @@ describe('Shorthand selector specifications', () => {
                 break;
             case CREATE_PUBLISHER:
                 session.Publisher.create(action.payload);
+                break;
+            case CREATE_BOOK:
+                session.Book.create(action.payload);
+                break;
+            case CREATE_COVER:
+                session.Cover.create(action.payload);
+                break;
+            case CREATE_AUTHOR:
+                session.Author.create(action.payload);
                 break;
             default: break;
             }
@@ -324,9 +336,94 @@ describe('Shorthand selector specifications', () => {
         });
     });
 
-    describe('one to one field selector specs', () => {});
-    describe('many to many field selector specs', () => {});
+    describe('one to one field selector specs', () => {
+        it('will compute forward oneToOne model for single model instances', () => {
+            const bookCover = createSelector(orm.Book.cover);
+            ormState = reducer(ormState, {
+                type: CREATE_COVER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(bookCover(ormState, 1)).toEqual(null);
+            ormState = reducer(ormState, {
+                type: CREATE_BOOK,
+                payload: {
+                    id: 1,
+                    cover: 123,
+                },
+            });
+            expect(bookCover(ormState, 1)).toEqual({
+                id: 123,
+            });
+        });
 
+        it('will compute backward oneToOne model for single model instances', () => {
+            const coverBook = createSelector(orm.Cover.book);
+            ormState = reducer(ormState, {
+                type: CREATE_BOOK,
+                payload: {
+                    id: 1,
+                    cover: 123,
+                },
+            });
+            expect(coverBook(ormState, 123)).toEqual(null);
+            ormState = reducer(ormState, {
+                type: CREATE_COVER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(coverBook(ormState, 123)).toEqual({
+                id: 1,
+                cover: 123,
+            });
+        });
+    });
+
+    describe('many to many field selector specs', () => {
+        it('will compute forward manyToMany models for single model instances', () => {
+            const authorPublishers = createSelector(orm.Author.publishers);
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(authorPublishers(ormState, 1)).toEqual(null);
+            ormState = reducer(ormState, {
+                type: CREATE_AUTHOR,
+                payload: {
+                    id: 1,
+                    publishers: [123],
+                },
+            });
+            expect(authorPublishers(ormState, 1)).toEqual([{
+                id: 123,
+            }]);
+        });
+
+        it('will compute backward manyToMany models for single model instances', () => {
+            const publisherAuthors = createSelector(orm.Publisher.authors);
+            ormState = reducer(ormState, {
+                type: CREATE_AUTHOR,
+                payload: {
+                    id: 1,
+                    publishers: [123],
+                },
+            });
+            expect(publisherAuthors(ormState, 123)).toEqual(null);
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(publisherAuthors(ormState, 123)).toEqual([{
+                id: 1,
+            }]);
+        });
+    });
 
     describe('mapping selector specs', () => {
         it('will map selector outputs', () => {

--- a/src/test/integration/selectors.js
+++ b/src/test/integration/selectors.js
@@ -69,14 +69,14 @@ describe('Shorthand selector specifications', () => {
 
     it('will recompute some model instances by ID array', () => {
         const publishers = createSelector(orm.Publisher);
-        expect(publishers(emptyState, []).length).toEqual(0);
+        expect(publishers(emptyState, [])).toHaveLength(0);
         expect(publishers.recomputations()).toEqual(1);
-        expect(publishers(emptyState, []).length).toEqual(0);
+        expect(publishers(emptyState, [])).toHaveLength(0);
         expect(publishers.recomputations()).toEqual(2);
         const zeroAndTwo = [0, 2];
-        expect(publishers(emptyState, zeroAndTwo).length).toEqual(0);
+        expect(publishers(emptyState, zeroAndTwo)).toHaveLength(0);
         expect(publishers.recomputations()).toEqual(3);
-        expect(publishers(emptyState, zeroAndTwo).length).toEqual(0);
+        expect(publishers(emptyState, zeroAndTwo)).toHaveLength(0);
         expect(publishers.recomputations()).toEqual(3);
         ormState = reducer(emptyState, {
             type: CREATE_PUBLISHER,
@@ -84,7 +84,7 @@ describe('Shorthand selector specifications', () => {
                 id: 1,
             },
         });
-        expect(publishers(ormState, zeroAndTwo).length).toEqual(0);
+        expect(publishers(ormState, zeroAndTwo)).toHaveLength(0);
         /**
          * Note that the above only recomputes because we need to
          * perform a full-table scan there, even if we knew before
@@ -98,17 +98,17 @@ describe('Shorthand selector specifications', () => {
                 id: 2,
             },
         });
-        expect(publishers(ormState, zeroAndTwo).length).toEqual(1);
+        expect(publishers(ormState, zeroAndTwo)).toHaveLength(1);
         expect(publishers.recomputations()).toEqual(5);
-        expect(publishers(ormState, zeroAndTwo).length).toEqual(1);
+        expect(publishers(ormState, zeroAndTwo)).toHaveLength(1);
         expect(publishers.recomputations()).toEqual(5);
     });
 
     it('will recompute all model instances', () => {
         const publishers = createSelector(orm.Publisher);
-        expect(publishers(emptyState).length).toEqual(0);
+        expect(publishers(emptyState)).toHaveLength(0);
         expect(publishers.recomputations()).toEqual(1);
-        expect(publishers(emptyState).length).toEqual(0);
+        expect(publishers(emptyState)).toHaveLength(0);
         expect(publishers.recomputations()).toEqual(1);
         ormState = reducer(emptyState, {
             type: CREATE_PUBLISHER,
@@ -116,7 +116,7 @@ describe('Shorthand selector specifications', () => {
                 id: 1,
             },
         });
-        expect(publishers(ormState).length).toEqual(1);
+        expect(publishers(ormState)).toHaveLength(1);
         expect(publishers.recomputations()).toEqual(2);
     });
 

--- a/src/test/integration/selectors.js
+++ b/src/test/integration/selectors.js
@@ -265,6 +265,9 @@ describe('Shorthand selector specifications', () => {
             expect(publisherNames(ormState, zeroAndTwo))
                 .toEqual([null, 'Other publisher name!']);
             expect(publisherNames.recomputations()).toEqual(5);
+            expect(publisherNames(ormState, zeroAndTwo))
+                .toEqual([null, 'Other publisher name!']);
+            expect(publisherNames.recomputations()).toEqual(5);
         });
 
         it('will compute attr fields for all model instances', () => {
@@ -280,6 +283,8 @@ describe('Shorthand selector specifications', () => {
                     name: 'Publisher name!'
                 },
             });
+            expect(publisherNames(ormState)).toEqual(['Publisher name!']);
+            expect(publisherNames.recomputations()).toEqual(2);
             expect(publisherNames(ormState)).toEqual(['Publisher name!']);
             expect(publisherNames.recomputations()).toEqual(2);
         });
@@ -313,6 +318,11 @@ describe('Shorthand selector specifications', () => {
             expect(moviePublisher(ormState)).toEqual([
                 { id: 123 },
             ]);
+            expect(moviePublisher.recomputations()).toEqual(6);
+            expect(moviePublisher(ormState, 1)).toEqual(
+                { id: 123 },
+            );
+            expect(moviePublisher.recomputations()).toEqual(6);
         });
 
         it('will compute backward FK models', () => {
@@ -400,6 +410,11 @@ describe('Shorthand selector specifications', () => {
             expect(bookCover(ormState)).toEqual([
                 { id: 123 },
             ]);
+            expect(bookCover.recomputations()).toBe(6);
+            expect(bookCover(ormState, 1)).toEqual(
+                { id: 123 },
+            );
+            expect(bookCover.recomputations()).toBe(6);
         });
 
         it('will compute backward oneToOne models', () => {
@@ -436,6 +451,12 @@ describe('Shorthand selector specifications', () => {
                     cover: 123,
                 },
             ]);
+            expect(coverBook.recomputations()).toBe(6);
+            expect(coverBook(ormState, 123)).toEqual({
+                id: 1,
+                cover: 123,
+            });
+            expect(coverBook.recomputations()).toBe(6);
         });
     });
 
@@ -471,6 +492,11 @@ describe('Shorthand selector specifications', () => {
                     { id: 123 },
                 ],
             ]);
+            expect(authorPublishers.recomputations()).toBe(6);
+            expect(authorPublishers(ormState, 1)).toEqual([
+                { id: 123 },
+            ]);
+            expect(authorPublishers.recomputations()).toBe(6);
         });
 
         it('will compute backward manyToMany models', () => {
@@ -504,6 +530,11 @@ describe('Shorthand selector specifications', () => {
                     { id: 1 },
                 ],
             ]);
+            expect(publisherAuthors.recomputations()).toBe(6);
+            expect(publisherAuthors(ormState, 123)).toEqual([
+                { id: 1 },
+            ]);
+            expect(publisherAuthors.recomputations()).toBe(6);
         });
     });
 
@@ -579,6 +610,10 @@ describe('Shorthand selector specifications', () => {
                     id: 1,
                 },
             });
+            expect(coverAuthors(ormState, 1)).toEqual([
+                { id: 3 }
+            ]);
+            expect(coverAuthors.recomputations()).toEqual(5);
             expect(coverAuthors(ormState, 1)).toEqual([
                 { id: 3 }
             ]);

--- a/src/test/integration/selectors.js
+++ b/src/test/integration/selectors.js
@@ -1,0 +1,111 @@
+import {
+    ORM, Session, createSelector
+} from '../..';
+import { createTestModels, avg } from '../helpers';
+
+describe('Selector memoization', () => {
+    let orm;
+    let reducer;
+    let emptyState;
+    let nextState;
+    let Book;
+    let Cover;
+    let Genre;
+    let Tag;
+    let Author;
+    let Publisher;
+    let Movie;
+
+    const CREATE_MOVIE = 'CREATE_MOVIE';
+    const CREATE_PUBLISHER = 'CREATE_PUBLISHER';
+
+    beforeEach(() => {
+        ({
+            Book,
+            Cover,
+            Genre,
+            Tag,
+            Author,
+            Movie,
+            Publisher,
+        } = createTestModels());
+        orm = new ORM({
+            stateSelector: (state) => state.orm,
+        });
+        orm.register(Book, Cover, Genre, Tag, Author, Movie, Publisher);
+        reducer = (state, action) => {
+            const session = orm.session(state || orm.getEmptyState());
+            switch (action.type) {
+            case CREATE_MOVIE:
+                session.MOVIE.create(action.payload);
+                break;
+            case CREATE_PUBLISHER:
+                session.PUBLISHER.create(action.payload);
+                break;
+            }
+            return session.state;
+        };
+        nextState = emptyState = orm.getEmptyState();
+    });
+
+    it('passes on input args', () => {
+        const ormState = state => state.orm;
+        /**
+         * The way we have to do it right now.
+         */
+const old = createSelector(
+    orm,
+    ormState,
+    (state, id) => id,
+    ({ Publisher }, id) => (
+        avg(Publisher.withId(id).movies.map(movie => movie.rating))
+    ),
+);
+        /**
+         * This is the desired new functionality.
+         */
+        const publisherRatingAvg = createSelector(
+            orm,
+            Publisher.movies,
+            (_, movies) => avg(movies.map(movie => movie.rating))
+        );
+        expect(() => publisherRatingAvg(emptyState, 0))
+            .toThrow('Publisher with id 0 doesn\'t exist');
+        nextState = reducer(nextState, {
+            type: CREATE_PUBLISHER,
+            payload: {
+                id: 123,
+            },
+        });
+        expect(publisherRatingAvg(nextState, 123)).toEqual(null);
+        nextState = reducer(nextState, {
+            type: CREATE_MOVIE,
+            payload: {
+                rating: 6,
+                publisher: 123,
+            },
+        });
+        nextState = reducer(nextState, {
+            type: CREATE_MOVIE,
+            payload: {
+                rating: 7,
+                publisher: 123,
+            },
+        });
+        expect(publisherRatingAvg(nextState, 123)).toEqual(6.5);
+    });
+
+//     it('orm.memo() works with a passed state selector', () => {
+
+//         const book = orm.memo(Book.withId);
+//         expect(book(emptyState, 1)).toBe(null);
+//         const nextState = reducer(emptyState, {
+//             id: 1,
+//             title: 'First book',
+//         });
+//         expect(book(nextState, 1).ref).toBe(
+//             orm.session(nextState).Book.withId(1).ref
+//         );
+//     });
+
+});

--- a/src/test/integration/selectors.js
+++ b/src/test/integration/selectors.js
@@ -140,7 +140,7 @@ describe('Shorthand selector specifications', () => {
     });
 
     describe('model selector specs', () => {
-        it('will recompute single model instances', () => {
+        it('will recompute single instances', () => {
             const publishers = createSelector(orm.Publisher);
             expect(publishers(emptyState, 1)).toEqual(null);
             expect(publishers.recomputations()).toEqual(1);
@@ -215,7 +215,7 @@ describe('Shorthand selector specifications', () => {
     });
 
     describe('attr field selector specs', () => {
-        it('will recompute attr fields for single model instances', () => {
+        it('will compute attr fields for single model instances', () => {
             const publisherNames = createSelector(orm.Publisher.name);
             expect(publisherNames(emptyState, 1)).toEqual(null);
             expect(publisherNames.recomputations()).toEqual(1);
@@ -232,7 +232,7 @@ describe('Shorthand selector specifications', () => {
             expect(publisherNames.recomputations()).toEqual(2);
         });
 
-        it('will recompute attr fields for some model instances', () => {
+        it('will compute attr fields for some model instances', () => {
             const publisherNames = createSelector(orm.Publisher.name);
             expect(publisherNames(emptyState, [])).toEqual([]);
             expect(publisherNames.recomputations()).toEqual(1);
@@ -267,7 +267,7 @@ describe('Shorthand selector specifications', () => {
             expect(publisherNames.recomputations()).toEqual(5);
         });
 
-        it('will recompute attr fields for all model instances', () => {
+        it('will compute attr fields for all model instances', () => {
             const publisherNames = createSelector(orm.Publisher.name);
             expect(publisherNames(emptyState)).toEqual([]);
             expect(publisherNames.recomputations()).toEqual(1);
@@ -286,7 +286,7 @@ describe('Shorthand selector specifications', () => {
     });
 
     describe('foreign key field selector specs', () => {
-        it('will compute forward FK model for single model instances', () => {
+        it('will compute forward FK models', () => {
             const moviePublisher = createSelector(orm.Movie.publisher);
             ormState = reducer(ormState, {
                 type: CREATE_PUBLISHER,
@@ -295,6 +295,8 @@ describe('Shorthand selector specifications', () => {
                 },
             });
             expect(moviePublisher(ormState, 1)).toEqual(null);
+            expect(moviePublisher(ormState, [1])).toEqual([null]);
+            expect(moviePublisher(ormState)).toEqual([]);
             ormState = reducer(ormState, {
                 type: CREATE_MOVIE,
                 payload: {
@@ -302,12 +304,18 @@ describe('Shorthand selector specifications', () => {
                     publisherId: 123,
                 },
             });
-            expect(moviePublisher(ormState, 1)).toEqual({
-                id: 123,
-            });
+            expect(moviePublisher(ormState, 1)).toEqual(
+                { id: 123 },
+            );
+            expect(moviePublisher(ormState, [1])).toEqual([
+                { id: 123 },
+            ]);
+            expect(moviePublisher(ormState)).toEqual([
+                { id: 123 },
+            ]);
         });
 
-        it('will compute backward FK models for single model instances', () => {
+        it('will compute backward FK models', () => {
             const publisherMovies = createSelector(orm.Publisher.movies);
             ormState = reducer(ormState, {
                 type: CREATE_PUBLISHER,
@@ -316,6 +324,12 @@ describe('Shorthand selector specifications', () => {
                 },
             });
             expect(publisherMovies(ormState, 123)).toEqual([]);
+            expect(publisherMovies(ormState, [123])).toEqual([
+                [],
+            ]);
+            expect(publisherMovies(ormState)).toEqual([
+                [],
+            ]);
             ormState = reducer(ormState, {
                 type: CREATE_MOVIE,
                 payload: {
@@ -325,6 +339,12 @@ describe('Shorthand selector specifications', () => {
             });
             expect(publisherMovies(ormState, 123)).toEqual([
                 { id: 1, publisherId: 123 }
+            ]);
+            expect(publisherMovies(ormState, [123])).toEqual([
+                [ { id: 1, publisherId: 123 } ],
+            ]);
+            expect(publisherMovies(ormState)).toEqual([
+                [ { id: 1, publisherId: 123 } ],
             ]);
             ormState = reducer(ormState, {
                 type: CREATE_MOVIE,
@@ -337,11 +357,23 @@ describe('Shorthand selector specifications', () => {
                 { id: 1, publisherId: 123 },
                 { id: 2, publisherId: 123 },
             ]);
+            expect(publisherMovies(ormState, [123])).toEqual([
+                [
+                    { id: 1, publisherId: 123 },
+                    { id: 2, publisherId: 123 },
+                ],
+            ]);
+            expect(publisherMovies(ormState)).toEqual([
+                [
+                    { id: 1, publisherId: 123 },
+                    { id: 2, publisherId: 123 },
+                ],
+            ]);
         });
     });
 
     describe('one to one field selector specs', () => {
-        it('will compute forward oneToOne model for single model instances', () => {
+        it('will compute forward oneToOne models', () => {
             const bookCover = createSelector(orm.Book.cover);
             ormState = reducer(ormState, {
                 type: CREATE_COVER,
@@ -350,47 +382,7 @@ describe('Shorthand selector specifications', () => {
                 },
             });
             expect(bookCover(ormState, 1)).toEqual(null);
-            ormState = reducer(ormState, {
-                type: CREATE_BOOK,
-                payload: {
-                    id: 1,
-                    cover: 123,
-                },
-            });
-            expect(bookCover(ormState, 1)).toEqual({
-                id: 123,
-            });
-        });
-
-        it('will compute forward oneToOne model for some model instances', () => {
-            const bookCover = createSelector(orm.Book.cover);
-            ormState = reducer(ormState, {
-                type: CREATE_COVER,
-                payload: {
-                    id: 123,
-                },
-            });
             expect(bookCover(ormState, [1])).toEqual([null]);
-            ormState = reducer(ormState, {
-                type: CREATE_BOOK,
-                payload: {
-                    id: 1,
-                    cover: 123,
-                },
-            });
-            expect(bookCover(ormState, [1])).toEqual([{
-                id: 123,
-            }]);
-        });
-
-        it('will compute forward oneToOne model for all model instances', () => {
-            const bookCover = createSelector(orm.Book.cover);
-            ormState = reducer(ormState, {
-                type: CREATE_COVER,
-                payload: {
-                    id: 123,
-                },
-            });
             expect(bookCover(ormState)).toEqual([]);
             ormState = reducer(ormState, {
                 type: CREATE_BOOK,
@@ -399,12 +391,18 @@ describe('Shorthand selector specifications', () => {
                     cover: 123,
                 },
             });
-            expect(bookCover(ormState)).toEqual([{
-                id: 123,
-            }]);
+            expect(bookCover(ormState, 1)).toEqual(
+                { id: 123 },
+            );
+            expect(bookCover(ormState, [1])).toEqual([
+                { id: 123 },
+            ]);
+            expect(bookCover(ormState)).toEqual([
+                { id: 123 },
+            ]);
         });
 
-        it('will compute backward oneToOne model for single model instances', () => {
+        it('will compute backward oneToOne models', () => {
             const coverBook = createSelector(orm.Cover.book);
             ormState = reducer(ormState, {
                 type: CREATE_BOOK,
@@ -414,6 +412,8 @@ describe('Shorthand selector specifications', () => {
                 },
             });
             expect(coverBook(ormState, 123)).toEqual(null);
+            expect(coverBook(ormState, [123])).toEqual([null]);
+            expect(coverBook(ormState)).toEqual([]);
             ormState = reducer(ormState, {
                 type: CREATE_COVER,
                 payload: {
@@ -424,55 +424,23 @@ describe('Shorthand selector specifications', () => {
                 id: 1,
                 cover: 123,
             });
-        });
-
-        it('will compute backward oneToOne model for some model instances', () => {
-            const coverBook = createSelector(orm.Cover.book);
-            ormState = reducer(ormState, {
-                type: CREATE_BOOK,
-                payload: {
+            expect(coverBook(ormState, [123])).toEqual([
+                {
                     id: 1,
                     cover: 123,
                 },
-            });
-            expect(coverBook(ormState, [123])).toEqual([null]);
-            ormState = reducer(ormState, {
-                type: CREATE_COVER,
-                payload: {
-                    id: 123,
-                },
-            });
-            expect(coverBook(ormState, [123])).toEqual([{
-                id: 1,
-                cover: 123,
-            }]);
-        });
-
-        it('will compute backward oneToOne model for all model instances', () => {
-            const coverBook = createSelector(orm.Cover.book);
-            ormState = reducer(ormState, {
-                type: CREATE_BOOK,
-                payload: {
+            ]);
+            expect(coverBook(ormState)).toEqual([
+                {
                     id: 1,
                     cover: 123,
                 },
-            });
-            expect(coverBook(ormState)).toEqual([]);
-            ormState = reducer(ormState, {
-                type: CREATE_COVER,
-                payload: {
-                    id: 123,
-                },
-            });
-            expect(coverBook(ormState)).toEqual([{
-                id: 1,
-                cover: 123,
-            }]);
+            ]);
         });
     });
 
     describe('many to many field selector specs', () => {
-        it('will compute forward manyToMany models for single model instances', () => {
+        it('will compute forward manyToMany models', () => {
             const authorPublishers = createSelector(orm.Author.publishers);
             ormState = reducer(ormState, {
                 type: CREATE_PUBLISHER,
@@ -481,49 +449,7 @@ describe('Shorthand selector specifications', () => {
                 },
             });
             expect(authorPublishers(ormState, 1)).toEqual(null);
-            ormState = reducer(ormState, {
-                type: CREATE_AUTHOR,
-                payload: {
-                    id: 1,
-                    publishers: [123],
-                },
-            });
-            expect(authorPublishers(ormState, 1)).toEqual([{
-                id: 123,
-            }]);
-        });
-
-        it('will compute forward manyToMany models for some model instances', () => {
-            const authorPublishers = createSelector(orm.Author.publishers);
-            ormState = reducer(ormState, {
-                type: CREATE_PUBLISHER,
-                payload: {
-                    id: 123,
-                },
-            });
             expect(authorPublishers(ormState, [1])).toEqual([null]);
-            ormState = reducer(ormState, {
-                type: CREATE_AUTHOR,
-                payload: {
-                    id: 1,
-                    publishers: [123],
-                },
-            });
-            expect(authorPublishers(ormState, [1])).toEqual([
-                [{
-                    id: 123,
-                }]
-            ]);
-        });
-
-        it('will compute forward manyToMany models for all model instances', () => {
-            const authorPublishers = createSelector(orm.Author.publishers);
-            ormState = reducer(ormState, {
-                type: CREATE_PUBLISHER,
-                payload: {
-                    id: 123,
-                },
-            });
             expect(authorPublishers(ormState)).toEqual([]);
             ormState = reducer(ormState, {
                 type: CREATE_AUTHOR,
@@ -532,14 +458,22 @@ describe('Shorthand selector specifications', () => {
                     publishers: [123],
                 },
             });
+            expect(authorPublishers(ormState, 1)).toEqual([
+                { id: 123 },
+            ]);
+            expect(authorPublishers(ormState, [1])).toEqual([
+                [
+                    { id: 123 },
+                ],
+            ]);
             expect(authorPublishers(ormState)).toEqual([
-                [{
-                    id: 123,
-                }]
+                [
+                    { id: 123 },
+                ],
             ]);
         });
 
-        it('will compute backward manyToMany models for single model instances', () => {
+        it('will compute backward manyToMany models', () => {
             const publisherAuthors = createSelector(orm.Publisher.authors);
             ormState = reducer(ormState, {
                 type: CREATE_AUTHOR,
@@ -549,49 +483,7 @@ describe('Shorthand selector specifications', () => {
                 },
             });
             expect(publisherAuthors(ormState, 123)).toEqual(null);
-            ormState = reducer(ormState, {
-                type: CREATE_PUBLISHER,
-                payload: {
-                    id: 123,
-                },
-            });
-            expect(publisherAuthors(ormState, 123)).toEqual([{
-                id: 1,
-            }]);
-        });
-
-        it('will compute backward manyToMany models for some model instances', () => {
-            const publisherAuthors = createSelector(orm.Publisher.authors);
-            ormState = reducer(ormState, {
-                type: CREATE_AUTHOR,
-                payload: {
-                    id: 1,
-                    publishers: [123],
-                },
-            });
             expect(publisherAuthors(ormState, [123])).toEqual([null]);
-            ormState = reducer(ormState, {
-                type: CREATE_PUBLISHER,
-                payload: {
-                    id: 123,
-                },
-            });
-            expect(publisherAuthors(ormState, [123])).toEqual([
-                [{
-                    id: 1,
-                }]
-            ]);
-        });
-
-        it('will compute backward manyToMany models for all model instances', () => {
-            const publisherAuthors = createSelector(orm.Publisher.authors);
-            ormState = reducer(ormState, {
-                type: CREATE_AUTHOR,
-                payload: {
-                    id: 1,
-                    publishers: [123],
-                },
-            });
             expect(publisherAuthors(ormState)).toEqual([]);
             ormState = reducer(ormState, {
                 type: CREATE_PUBLISHER,
@@ -599,10 +491,18 @@ describe('Shorthand selector specifications', () => {
                     id: 123,
                 },
             });
+            expect(publisherAuthors(ormState, 123)).toEqual([
+                { id: 1 },
+            ]);
+            expect(publisherAuthors(ormState, [123])).toEqual([
+                [
+                    { id: 1 },
+                ],
+            ]);
             expect(publisherAuthors(ormState)).toEqual([
-                [{
-                    id: 1,
-                }]
+                [
+                    { id: 1 },
+                ],
             ]);
         });
     });
@@ -637,7 +537,7 @@ describe('Shorthand selector specifications', () => {
                 .not.toBeUndefined();
         });
 
-        it('will recompute for single model instances', () => {
+        it('will compute for single model instances', () => {
             const coverAuthors = createSelector(
                 orm.Cover.book.publisher.authors
             );
@@ -699,11 +599,11 @@ describe('Shorthand selector specifications', () => {
         });
 
         it('will throw for non-matching specs', () => {
-            expect(() => orm.Author.books.map(orm.Book))
+            expect(() => orm.Book.author.books.map(orm.Book))
                 .toThrow('Cannot select models in a `map()` call. If you just want the `books` as a ref array then you can simply drop the `map()`. Otherwise make sure you\'re passing a field selector of the form `Book.<field>` or a custom selector instead.');
-            expect(() => orm.Author.books.map(orm.Movie))
+            expect(() => orm.Book.author.books.map(orm.Movie))
                 .toThrow('Cannot select `Movie` models in this `map()` call. Make sure you\'re passing a field selector of the form `Book.<field>` or a custom selector instead.');
-            expect(() => orm.Author.books.map(orm.Movie.name))
+            expect(() => orm.Book.author.books.map(orm.Movie.name))
                 .toThrow('Cannot select fields of the `Movie` model in this `map()` call. Make sure you\'re passing a field selector of the form `Book.<field>` or a custom selector instead.');
         });
 

--- a/src/test/integration/selectors.js
+++ b/src/test/integration/selectors.js
@@ -166,8 +166,28 @@ describe('Shorthand selector specifications', () => {
             expect(publisherNames.recomputations()).toEqual(2);
         });
 
-        /*
-        it('will compute related models for single model instances', () => {
+        it('will compute forward FK model for single model instances', () => {
+            const moviePublisher = createSelector(orm.Movie.publisher);
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(moviePublisher(ormState, 1)).toEqual(null);
+            ormState = reducer(ormState, {
+                type: CREATE_MOVIE,
+                payload: {
+                    id: 1,
+                    publisherId: 123,
+                },
+            });
+            expect(moviePublisher(ormState, 1)).toEqual({
+                id: 123,
+            });
+        });
+
+        it('will compute backward FK models for single model instances', () => {
             const publisherMovies = createSelector(orm.Publisher.movies);
             ormState = reducer(ormState, {
                 type: CREATE_PUBLISHER,
@@ -180,25 +200,24 @@ describe('Shorthand selector specifications', () => {
                 type: CREATE_MOVIE,
                 payload: {
                     id: 1,
-                    publisher: 123,
+                    publisherId: 123,
                 },
             });
             expect(publisherMovies(ormState, 123)).toEqual([
-                { id: 1, publisher: 123 }
+                { id: 1, publisherId: 123 }
             ]);
             ormState = reducer(ormState, {
                 type: CREATE_MOVIE,
                 payload: {
                     id: 2,
-                    publisher: 123,
+                    publisherId: 123,
                 },
             });
             expect(publisherMovies(ormState, 123)).toEqual([
-                { id: 1, publisher: 123 },
-                { id: 2, publisher: 123 },
+                { id: 1, publisherId: 123 },
+                { id: 2, publisherId: 123 },
             ]);
         });
-        */
 
         it('will recompute attr fields for some model instances', () => {
             const publisherNames = createSelector(orm.Publisher.name);

--- a/src/test/integration/selectors.js
+++ b/src/test/integration/selectors.js
@@ -239,9 +239,11 @@ describe('Shorthand selector specifications', () => {
             expect(publisherNames(emptyState, [])).toEqual([]);
             expect(publisherNames.recomputations()).toEqual(2);
             const zeroAndTwo = [0, 2];
-            expect(publisherNames(emptyState, zeroAndTwo)).toEqual([]);
+            expect(publisherNames(emptyState, zeroAndTwo))
+                .toEqual([null, null]);
             expect(publisherNames.recomputations()).toEqual(3);
-            expect(publisherNames(emptyState, zeroAndTwo)).toEqual([]);
+            expect(publisherNames(emptyState, zeroAndTwo))
+                .toEqual([null, null]);
             expect(publisherNames.recomputations()).toEqual(3);
             ormState = reducer(emptyState, {
                 type: CREATE_PUBLISHER,
@@ -250,7 +252,8 @@ describe('Shorthand selector specifications', () => {
                     name: 'Publisher name!'
                 },
             });
-            expect(publisherNames(ormState, zeroAndTwo)).toEqual([]);
+            expect(publisherNames(ormState, zeroAndTwo))
+                .toEqual([null, null]);
             expect(publisherNames.recomputations()).toEqual(4);
             ormState = reducer(ormState, {
                 type: CREATE_PUBLISHER,
@@ -259,7 +262,8 @@ describe('Shorthand selector specifications', () => {
                     name: 'Other publisher name!'
                 },
             });
-            expect(publisherNames(ormState, zeroAndTwo)).toEqual(['Other publisher name!']);
+            expect(publisherNames(ormState, zeroAndTwo))
+                .toEqual([null, 'Other publisher name!']);
             expect(publisherNames.recomputations()).toEqual(5);
         });
 
@@ -358,6 +362,48 @@ describe('Shorthand selector specifications', () => {
             });
         });
 
+        it('will compute forward oneToOne model for some model instances', () => {
+            const bookCover = createSelector(orm.Book.cover);
+            ormState = reducer(ormState, {
+                type: CREATE_COVER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(bookCover(ormState, [1])).toEqual([null]);
+            ormState = reducer(ormState, {
+                type: CREATE_BOOK,
+                payload: {
+                    id: 1,
+                    cover: 123,
+                },
+            });
+            expect(bookCover(ormState, [1])).toEqual([{
+                id: 123,
+            }]);
+        });
+
+        it('will compute forward oneToOne model for all model instances', () => {
+            const bookCover = createSelector(orm.Book.cover);
+            ormState = reducer(ormState, {
+                type: CREATE_COVER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(bookCover(ormState)).toEqual([]);
+            ormState = reducer(ormState, {
+                type: CREATE_BOOK,
+                payload: {
+                    id: 1,
+                    cover: 123,
+                },
+            });
+            expect(bookCover(ormState)).toEqual([{
+                id: 123,
+            }]);
+        });
+
         it('will compute backward oneToOne model for single model instances', () => {
             const coverBook = createSelector(orm.Cover.book);
             ormState = reducer(ormState, {
@@ -378,6 +424,50 @@ describe('Shorthand selector specifications', () => {
                 id: 1,
                 cover: 123,
             });
+        });
+
+        it('will compute backward oneToOne model for some model instances', () => {
+            const coverBook = createSelector(orm.Cover.book);
+            ormState = reducer(ormState, {
+                type: CREATE_BOOK,
+                payload: {
+                    id: 1,
+                    cover: 123,
+                },
+            });
+            expect(coverBook(ormState, [123])).toEqual([null]);
+            ormState = reducer(ormState, {
+                type: CREATE_COVER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(coverBook(ormState, [123])).toEqual([{
+                id: 1,
+                cover: 123,
+            }]);
+        });
+
+        it('will compute backward oneToOne model for all model instances', () => {
+            const coverBook = createSelector(orm.Cover.book);
+            ormState = reducer(ormState, {
+                type: CREATE_BOOK,
+                payload: {
+                    id: 1,
+                    cover: 123,
+                },
+            });
+            expect(coverBook(ormState)).toEqual([]);
+            ormState = reducer(ormState, {
+                type: CREATE_COVER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(coverBook(ormState)).toEqual([{
+                id: 1,
+                cover: 123,
+            }]);
         });
     });
 
@@ -403,6 +493,52 @@ describe('Shorthand selector specifications', () => {
             }]);
         });
 
+        it('will compute forward manyToMany models for some model instances', () => {
+            const authorPublishers = createSelector(orm.Author.publishers);
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(authorPublishers(ormState, [1])).toEqual([null]);
+            ormState = reducer(ormState, {
+                type: CREATE_AUTHOR,
+                payload: {
+                    id: 1,
+                    publishers: [123],
+                },
+            });
+            expect(authorPublishers(ormState, [1])).toEqual([
+                [{
+                    id: 123,
+                }]
+            ]);
+        });
+
+        it('will compute forward manyToMany models for all model instances', () => {
+            const authorPublishers = createSelector(orm.Author.publishers);
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(authorPublishers(ormState)).toEqual([]);
+            ormState = reducer(ormState, {
+                type: CREATE_AUTHOR,
+                payload: {
+                    id: 1,
+                    publishers: [123],
+                },
+            });
+            expect(authorPublishers(ormState)).toEqual([
+                [{
+                    id: 123,
+                }]
+            ]);
+        });
+
         it('will compute backward manyToMany models for single model instances', () => {
             const publisherAuthors = createSelector(orm.Publisher.authors);
             ormState = reducer(ormState, {
@@ -423,10 +559,64 @@ describe('Shorthand selector specifications', () => {
                 id: 1,
             }]);
         });
+
+        it('will compute backward manyToMany models for some model instances', () => {
+            const publisherAuthors = createSelector(orm.Publisher.authors);
+            ormState = reducer(ormState, {
+                type: CREATE_AUTHOR,
+                payload: {
+                    id: 1,
+                    publishers: [123],
+                },
+            });
+            expect(publisherAuthors(ormState, [123])).toEqual([null]);
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(publisherAuthors(ormState, [123])).toEqual([
+                [{
+                    id: 1,
+                }]
+            ]);
+        });
+
+        it('will compute backward manyToMany models for all model instances', () => {
+            const publisherAuthors = createSelector(orm.Publisher.authors);
+            ormState = reducer(ormState, {
+                type: CREATE_AUTHOR,
+                payload: {
+                    id: 1,
+                    publishers: [123],
+                },
+            });
+            expect(publisherAuthors(ormState)).toEqual([]);
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(publisherAuthors(ormState)).toEqual([
+                [{
+                    id: 1,
+                }]
+            ]);
+        });
     });
 
     describe('mapping selector specs', () => {
-        it('will map selector outputs for forward foreign key selectors', () => {
+        it('will throw for non foreign key fields', () => {
+            expect(() => orm.Publisher.movies.map(null))
+                .toThrow('`map()` requires a selector as an input. Received: null of type object');
+            const publisherName = createSelector(orm.Publisher.name);
+            expect(() => orm.Author.publishers.map(publisherName))
+                .toThrow('Cannot map selectors for other fields than foreign key fields');
+        });
+
+        it('will map selector outputs for forward foreign key selectors and single instances', () => {
             const movieRating = createSelector(orm.Movie.rating);
             const publisherMovieRatings = createSelector(
                 orm.Publisher.movies.map(movieRating)
@@ -457,7 +647,77 @@ describe('Shorthand selector specifications', () => {
             expect(publisherMovieRatings(ormState, 123)).toEqual([6, 7]);
         });
 
-        it('will map selector outputs for backward foreign key selectors', () => {
+        it('will map selector outputs for forward foreign key selectors and some instances', () => {
+            const movieRating = createSelector(orm.Movie.rating);
+            const publisherMovieRatings = createSelector(
+                orm.Publisher.movies.map(movieRating)
+            );
+            expect(publisherMovieRatings(emptyState, [123]))
+                .toEqual([null]); // publisher doesn't exist yet
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(publisherMovieRatings(ormState, [123])).toEqual([
+                [],
+            ]);
+            ormState = reducer(ormState, {
+                type: CREATE_MOVIE,
+                payload: {
+                    rating: 6,
+                    publisherId: 123,
+                },
+            });
+            ormState = reducer(ormState, {
+                type: CREATE_MOVIE,
+                payload: {
+                    rating: 7,
+                    publisherId: 123,
+                },
+            });
+            expect(publisherMovieRatings(ormState, [123])).toEqual([
+                [6, 7],
+            ]);
+        });
+
+        it('will map selector outputs for forward foreign key selectors and all instances', () => {
+            const movieRating = createSelector(orm.Movie.rating);
+            const publisherMovieRatings = createSelector(
+                orm.Publisher.movies.map(movieRating)
+            );
+            expect(publisherMovieRatings(emptyState))
+                .toEqual([]); // publisher doesn't exist yet
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 123,
+                },
+            });
+            expect(publisherMovieRatings(ormState)).toEqual([
+                [],
+            ]);
+            ormState = reducer(ormState, {
+                type: CREATE_MOVIE,
+                payload: {
+                    rating: 6,
+                    publisherId: 123,
+                },
+            });
+            ormState = reducer(ormState, {
+                type: CREATE_MOVIE,
+                payload: {
+                    rating: 7,
+                    publisherId: 123,
+                },
+            });
+            expect(publisherMovieRatings(ormState)).toEqual([
+                [6, 7],
+            ]);
+        });
+
+        it('will map selector outputs for backward foreign key selectors and single instance', () => {
             const publisherName = createSelector(orm.Publisher.name);
             const moviePublisherName = createSelector(
                 orm.Movie.publisher.map(publisherName)
@@ -481,6 +741,58 @@ describe('Shorthand selector specifications', () => {
                 },
             });
             expect(moviePublisherName(ormState, 1)).toEqual('Redux-ORM studios');
+        });
+
+        it('will map selector outputs for backward foreign key selectors and some instances', () => {
+            const publisherName = createSelector(orm.Publisher.name);
+            const moviePublisherName = createSelector(
+                orm.Movie.publisher.map(publisherName)
+            );
+            expect(moviePublisherName(emptyState, [1]))
+                .toEqual([null]); // movie doesn't exist yet
+            ormState = reducer(ormState, {
+                type: CREATE_MOVIE,
+                payload: {
+                    id: 1,
+                    publisherId: 123,
+                },
+            });
+            expect(moviePublisherName(ormState, [1]))
+                .toEqual([null]); // publisher doesn't exist yet
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 123,
+                    name: 'Redux-ORM studios',
+                },
+            });
+            expect(moviePublisherName(ormState, [1])).toEqual(['Redux-ORM studios']);
+        });
+
+        it('will map selector outputs for backward foreign key selectors and all instances', () => {
+            const publisherName = createSelector(orm.Publisher.name);
+            const moviePublisherName = createSelector(
+                orm.Movie.publisher.map(publisherName)
+            );
+            expect(moviePublisherName(emptyState))
+                .toEqual([]); // movie doesn't exist yet
+            ormState = reducer(ormState, {
+                type: CREATE_MOVIE,
+                payload: {
+                    id: 1,
+                    publisherId: 123,
+                },
+            });
+            expect(moviePublisherName(ormState))
+                .toEqual([null]); // publisher doesn't exist yet
+            ormState = reducer(ormState, {
+                type: CREATE_PUBLISHER,
+                payload: {
+                    id: 123,
+                    name: 'Redux-ORM studios',
+                },
+            });
+            expect(moviePublisherName(ormState)).toEqual(['Redux-ORM studios']);
         });
 
         it('can be combined when used as input selectors ', () => {

--- a/src/test/unit/Database.js
+++ b/src/test/unit/Database.js
@@ -3,7 +3,8 @@ import createDatabase from '../../db';
 import Table from '../../db/Table';
 import { getBatchToken } from '../../utils';
 import {
-    FILTER, CREATE, UPDATE, DELETE, SUCCESS
+    FILTER, CREATE, UPDATE, DELETE, SUCCESS,
+    STATE_FLAG_KEY, STATE_FLAG_VALUE
 } from '../../constants';
 
 describe('createDatabase', () => {
@@ -23,6 +24,7 @@ describe('createDatabase', () => {
 
     it('getEmptyState', () => {
         expect(emptyState).toEqual({
+            [STATE_FLAG_KEY]: STATE_FLAG_VALUE,
             Book: {
                 indexes: {},
                 items: [],
@@ -65,6 +67,7 @@ describe('createDatabase', () => {
         expect(payload).toBe(props);
         expect(state).not.toBe(emptyState);
         expect(state).toEqual({
+            [STATE_FLAG_KEY]: STATE_FLAG_VALUE,
             Book: {
                 items: [0],
                 itemsById: {
@@ -97,6 +100,7 @@ describe('createDatabase', () => {
         expect(payload).toEqual({ id: 0, name: 'Example Book' });
         expect(state).not.toBe(emptyState);
         expect(state).toEqual({
+            [STATE_FLAG_KEY]: STATE_FLAG_VALUE,
             Book: {
                 items: [0],
                 itemsById: {
@@ -136,6 +140,7 @@ describe('createDatabase', () => {
         expect(payload2).toEqual({ id: 1, name: 'Example Book Two' });
         expect(state2).toBe(state);
         expect(state2).toEqual({
+            [STATE_FLAG_KEY]: STATE_FLAG_VALUE,
             Book: {
                 items: [0, 1],
                 itemsById: {

--- a/src/test/unit/Database.js
+++ b/src/test/unit/Database.js
@@ -4,7 +4,7 @@ import Table from '../../db/Table';
 import { getBatchToken } from '../../utils';
 import {
     FILTER, CREATE, UPDATE, DELETE, SUCCESS,
-    STATE_FLAG_KEY, STATE_FLAG_VALUE
+    STATE_FLAG,
 } from '../../constants';
 
 describe('createDatabase', () => {
@@ -24,7 +24,7 @@ describe('createDatabase', () => {
 
     it('getEmptyState', () => {
         expect(emptyState).toEqual({
-            [STATE_FLAG_KEY]: STATE_FLAG_VALUE,
+            [STATE_FLAG]: STATE_FLAG,
             Book: {
                 indexes: {},
                 items: [],
@@ -67,7 +67,7 @@ describe('createDatabase', () => {
         expect(payload).toBe(props);
         expect(state).not.toBe(emptyState);
         expect(state).toEqual({
-            [STATE_FLAG_KEY]: STATE_FLAG_VALUE,
+            [STATE_FLAG]: STATE_FLAG,
             Book: {
                 items: [0],
                 itemsById: {
@@ -100,7 +100,7 @@ describe('createDatabase', () => {
         expect(payload).toEqual({ id: 0, name: 'Example Book' });
         expect(state).not.toBe(emptyState);
         expect(state).toEqual({
-            [STATE_FLAG_KEY]: STATE_FLAG_VALUE,
+            [STATE_FLAG]: STATE_FLAG,
             Book: {
                 items: [0],
                 itemsById: {
@@ -140,7 +140,7 @@ describe('createDatabase', () => {
         expect(payload2).toEqual({ id: 1, name: 'Example Book Two' });
         expect(state2).toBe(state);
         expect(state2).toEqual({
-            [STATE_FLAG_KEY]: STATE_FLAG_VALUE,
+            [STATE_FLAG]: STATE_FLAG,
             Book: {
                 items: [0, 1],
                 itemsById: {

--- a/src/test/unit/ORM.js
+++ b/src/test/unit/ORM.js
@@ -2,7 +2,7 @@ import {
     ORM, Session, Model, oneToOne, fk, many
 } from '../..';
 import { createTestModels } from '../helpers';
-import { STATE_FLAG_KEY, STATE_FLAG_VALUE } from '../../constants';
+import { STATE_FLAG } from '../../constants';
 
 describe('ORM', () => {
     it('constructor works', () => {
@@ -195,7 +195,7 @@ describe('ORM', () => {
             const defaultState = orm.getEmptyState();
 
             expect(defaultState).toEqual({
-                [STATE_FLAG_KEY]: STATE_FLAG_VALUE,
+                [STATE_FLAG]: STATE_FLAG,
                 Book: {
                     items: [],
                     itemsById: {},

--- a/src/test/unit/ORM.js
+++ b/src/test/unit/ORM.js
@@ -2,6 +2,7 @@ import {
     ORM, Session, Model, oneToOne, fk, many
 } from '../..';
 import { createTestModels } from '../helpers';
+import { STATE_FLAG_KEY, STATE_FLAG_VALUE } from '../../constants';
 
 describe('ORM', () => {
     it('constructor works', () => {
@@ -194,6 +195,7 @@ describe('ORM', () => {
             const defaultState = orm.getEmptyState();
 
             expect(defaultState).toEqual({
+                [STATE_FLAG_KEY]: STATE_FLAG_VALUE,
                 Book: {
                     items: [],
                     itemsById: {},


### PR DESCRIPTION
Implements #251 and contains checks to avoid #256.

- [x] Require passing at least one selector with an `ORM` reference.
- [x] Allow and require passing a `stateSelector` option during `ORM` construction.
- [x] Add re-reselect to dependencies.
---
```js
const publishers = createSelector(orm.Publisher);
```

- [x] `publishers(state)`:
```js
Publisher.all.toRefArray()
```
- [x] `publishers(state, 1)`: `null` or
```js
Publisher.withId(1).ref
```
- [x] `publishers(state, [1, 2])`:
```js
[1, 2].map(id => Publisher.withId(id).toRefArray())
```

---

```js
const publisherMovies = createSelector(orm.Publisher.movies);
```
- [x] `publisherMovies(state)`:
```js
Publisher.all().toModelArray().map(publisher => publisher.movies.toRefArray())
```
- [x] `publisherMovies(state, 1)`: `[]` or
```js
Publisher.withId(1).movies.toRefArray()
```

---

```js
// given the following:
const movieRating = createSelector(
    orm.Movie,
    movie => movie.rating
);
// then
const publisherMovieRatings = createSelector(
    orm.Publisher.movies.map(movieRating)
);
```
- [x] `publisherMovieRatings(state)`:
```js
createSelector(
    state => state,
    orm.Publisher.movies,
    (state, movies) => movies.map((state, i) => movieRating(state, movies[i].ref.id))
)
```
- [x] `publisherMovieRatings(state, 1)`: same as above
- [x] `publisherMovieRatings(state, [1, 2])`: same as above
- ~Allow for all types of relationship fields (`oneToOne`, `fk`, `many`)~ only collections
- [x] Allow passing selector specs as the selector in `orm.<Model>.<field>.map(<selector>)`, e.g:
```js
const authorPublishers = createSelector(
    orm.Author.books.map(orm.Book.publisher)
);
authorPublishers(state, 1);
// Author.withId(1).books.toModelArray().map(book => book.publisher && book.publisher.ref)
```
---
- [x] Remove `ORM#createReducer` and `ORM#createSelector` to prevent reselect from being bundled unnecessarily.
- [x] Cache selectors based on their position in `orm.<subtree>`:
    - `orm.<Model>`
    - `orm.<Model>.<field>`
    - `orm.<Model>.<field1>.….<fieldN>` recursively
        - only for field `1` to field `n - 1` (potentially also field `n`) being single referenced relationship fields,
for instance `orm.Movie.director.userAccount.paymentAccount.payments`
    - ~`orm.<Model>.map(<selector>)`~ same as passing `selector`
    - [x] `orm.<Model>.<field1>.….<fieldN>.map(<selector>)`
        - Use nested maps in selector cache so that we can cache by selector references.

---
To do in the future:
- Allow passing array of IDs to `Model.filter`, as in `Publisher.filter({ id: [1, 2] })`.