### PR TITLE
fix orm.<QuerySet>.<orderBy> orders parameter handling

### DIFF
--- a/src/db/Table.js
+++ b/src/db/Table.js
@@ -1,12 +1,10 @@
-import reject from 'lodash/reject';
+import ops from 'immutable-ops';
 import filter from 'lodash/filter';
 import orderBy from 'lodash/orderBy';
+import reject from 'lodash/reject';
 import sortBy from 'lodash/sortBy';
-import ops from 'immutable-ops';
 
-import {
-    FILTER, EXCLUDE, ORDER_BY,
-} from '../constants';
+import { EXCLUDE, FILTER, ORDER_BY } from '../constants';
 import { clauseFiltersByAttribute, clauseReducesResultSetSize } from '../utils';
 
 const DEFAULT_TABLE_OPTIONS = {
@@ -45,6 +43,19 @@ function idSequencer(_currMax, userPassedId) {
         newMax, // new max id
         newId, // id to use for row creation
     ];
+}
+
+/**
+ * Adapt order directions array to @{lodash.orderBy} API.
+ * @param {Array<Boolean|'asc'|'desc'>} orders? - an array of optional order query directions as provided to {@Link {QuerySet.orderBy}}
+ * @return {Array<'asc'|'desc'>|undefined} A normalized ordering array or null if non was provided.
+ */
+function normalizeOrders(orders) {
+    if (orders === undefined) {
+        return undefined;
+    }
+    const convert = order => (order === false ? 'desc' : 'asc');
+    return Array.isArray(orders) ? orders.map(convert) : convert(orders);
 }
 
 /**
@@ -265,7 +276,7 @@ const Table = class Table {
             }
             case ORDER_BY: {
                 const [iteratees, orders] = payload;
-                return orderBy(rows, iteratees, orders);
+                return orderBy(rows, iteratees, normalizeOrders(orders));
             }
             default:
                 return rows;

--- a/src/test/unit/Table.js
+++ b/src/test/unit/Table.js
@@ -1,7 +1,7 @@
 import deepFreeze from 'deep-freeze';
+import { EXCLUDE, FILTER, ORDER_BY } from '../../constants';
 import Table from '../../db/Table';
 import { getBatchToken } from '../../utils';
-import { FILTER, EXCLUDE, ORDER_BY } from '../../constants';
 
 describe('Table', () => {
     describe('prototype methods', () => {
@@ -156,7 +156,10 @@ describe('Table', () => {
         });
 
         it('orderBy works correctly with prop argument', () => {
-            const clauses = [{ type: ORDER_BY, payload: [['data'], ['inc']] }];
+            const clauses = [{
+                type: ORDER_BY,
+                payload: [['data'], ['asc']],
+            }];
             const result = table.query(state, clauses);
             expect(result.map(row => row.data)).toEqual(['awesomedata', 'cooldata', 'verycooldata!']);
         });
@@ -165,6 +168,56 @@ describe('Table', () => {
             const clauses = [{ type: ORDER_BY, payload: [row => row.data, undefined] }];
             const result = table.query(state, clauses);
             expect(result.map(row => row.data)).toEqual(['awesomedata', 'cooldata', 'verycooldata!']);
+        });
+
+        it('orderBy works correctly with true orders', () => {
+            const clauses = [{
+                type: ORDER_BY,
+                payload: [['data'], [true]],
+            }];
+            const result = table.query(state, clauses);
+            expect(result.map(row => row.data))
+                .toEqual(['awesomedata', 'cooldata', 'verycooldata!']);
+        });
+
+        it('orderBy works correctly with false orders', () => {
+            const clauses = [{
+                type: ORDER_BY,
+                payload: [['data'], [false]],
+            }];
+            const result = table.query(state, clauses);
+            expect(result.map(row => row.data))
+                .toEqual(['verycooldata!', 'cooldata', 'awesomedata']);
+        });
+
+        it('orderBy works correctly with non-array arguments', () => {
+            const clauses = [{
+                type: ORDER_BY,
+                payload: ['data', false],
+            }];
+            const result = table.query(state, clauses);
+            expect(result.map(row => row.data))
+                .toEqual(['verycooldata!', 'cooldata', 'awesomedata']);
+        });
+
+        it('orderBy works correctly with mixed orders', () => {
+            const clauses = [{
+                type: ORDER_BY,
+                payload: [[row => (row.data.includes('cool') ? 1 : 0), 'id'], [false, 'asc']],
+            }];
+            const result = table.query(state, clauses);
+            expect(result.map(row => row.data))
+                .toEqual(['cooldata', 'verycooldata!', 'awesomedata']);
+        });
+
+        it('orderBy works correctly without orders', () => {
+            const clauses = [{
+                type: ORDER_BY,
+                payload: ['id'],
+            }];
+            const result = table.query(state, clauses);
+            expect(result.map(row => row.data))
+                .toEqual(['cooldata', 'verycooldata!', 'awesomedata']);
         });
 
         it('exclude works correctly with object argument', () => {


### PR DESCRIPTION
Fix for #260, I've added few lines of code to handle boolean orders parameters along with `'asc'` and `'desc'` as per documentation content along with tests to cover previously missed scenarios.

* [x] Make sure you propose PR to correct branch: hotfix for `master`, feature for latest active branch `feature/x`.
* [x] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [x] Rebase before creating a PR to keep commit history clear.
* [x] Add some descriptions and refer relative issues for you PR.
