### PR TITLE
feature: specify relations using Model classes

### DIFF
--- a/src/fields.js
+++ b/src/fields.js
@@ -225,6 +225,16 @@ export class Attribute extends Field {
 }
 
 /**
+ * @private
+ */
+function normalizeModelReference(modelNameOrClass) {
+    if (!modelNameOrClass || typeof modelNameOrClass === 'string') {
+        return modelNameOrClass;
+    }
+    return modelNameOrClass.modelName;
+}
+
+/**
  * @ignore
  */
 export class RelationalField extends Field {
@@ -232,13 +242,13 @@ export class RelationalField extends Field {
         super();
         if (args.length === 1 && typeof args[0] === 'object') {
             const opts = args[0];
-            this.toModelName = opts.to;
+            this.toModelName = normalizeModelReference(opts.to);
             this.relatedName = opts.relatedName;
-            this.through = opts.through;
+            this.through = normalizeModelReference(opts.through);
             this.throughFields = opts.throughFields;
             this.as = opts.as;
         } else {
-            [this.toModelName, this.relatedName] = args;
+            [this.toModelName, this.relatedName] = [normalizeModelReference(args[0]), args[1]];
         }
     }
 

--- a/src/test/ReferencedModel.js
+++ b/src/test/ReferencedModel.js
@@ -1,0 +1,7 @@
+import { Model } from '../index';
+
+export default class ReferencedModel extends Model {
+    static get modelName() {
+        return 'ReferencedModel';
+    }
+}

--- a/src/test/ReferencingModel.js
+++ b/src/test/ReferencingModel.js
@@ -1,0 +1,30 @@
+import {
+    fk, many, Model, oneToOne
+} from '../index';
+import ReferencedModel from './ReferencedModel';
+// eslint-disable-next-line import/no-cycle
+import ThroughModel from './ThroughModel';
+
+export default class ReferencingModel extends Model {
+    static get modelName() {
+        return 'ReferencingModel';
+    }
+
+    static get fields() {
+        return {
+            fkField: fk({
+                to: ReferencedModel,
+                relatedName: 'reverseFkField'
+            }),
+            oneToOneField:
+                oneToOne(ReferencedModel, 'reverseOneToOneField'),
+            manyField:
+                many({
+                    to: ReferencedModel,
+                    relatedName: 'reverseManyField',
+                    through: ThroughModel,
+                    throughFields: ['referencingModel', 'referencedModel']
+                })
+        };
+    }
+}

--- a/src/test/ThroughModel.js
+++ b/src/test/ThroughModel.js
@@ -1,0 +1,17 @@
+import { fk, Model } from '../index';
+import ReferencedModel from './ReferencedModel';
+// eslint-disable-next-line import/no-cycle
+import ReferencingModel from './ReferencingModel';
+
+export default class ThroughModel extends Model {
+    static get modelName() {
+        return 'ThroughModel';
+    }
+
+    static get fields() {
+        return {
+            referencedModel: fk(ReferencedModel),
+            referencingModel: fk(ReferencingModel)
+        };
+    }
+}

--- a/src/test/functional/modelDeclarations.js
+++ b/src/test/functional/modelDeclarations.js
@@ -1,0 +1,47 @@
+/* eslint-disable no-shadow */
+import { ORM } from '../../index';
+import ReferencedModel from '../ReferencedModel';
+import ReferencingModel from '../ReferencingModel';
+import ThroughModel from '../ThroughModel';
+
+describe('specifying relations using Model classes works', () => {
+    const orm = new ORM();
+    orm.register(ReferencedModel, ReferencingModel, ThroughModel);
+    let session;
+
+    beforeEach(() => {
+        session = orm.session(orm.getEmptyState());
+    });
+
+    it('correctly handles Model class provided to descriptor function as first argument', () => {
+        const { ReferencedModel, ReferencingModel } = session;
+
+        ReferencedModel.create({ id: 1 });
+        ReferencingModel.create({ id: 1, oneToOneField: 1 });
+
+        expect(ReferencedModel.withId(1).reverseOneToOneField.ref).toEqual({ id: 1, oneToOneField: 1 });
+        expect(ReferencingModel.withId(1).oneToOneField.ref).toEqual({ id: 1 });
+    });
+
+    it('correctly handles Model class provided to descriptor function within the opts object', () => {
+        const { ReferencedModel, ReferencingModel } = session;
+
+        ReferencedModel.create({ id: 1 });
+        ReferencingModel.create({ id: 1, fkField: 1 });
+        ReferencingModel.create({ id: 2, fkField: 1 });
+
+        expect(ReferencedModel.withId(1).reverseFkField.count()).toEqual(2);
+    });
+
+    it('correctly handles Model class provided as an explicit through model', () => {
+        const { ReferencedModel, ReferencingModel, ThroughModel } = session;
+
+        ReferencedModel.create({ id: 1 });
+        ReferencedModel.create({ id: 2 });
+        ReferencingModel.create({ id: 1, manyField: [1, 2] });
+        ReferencingModel.create({ id: 2, manyField: [1, 2] });
+
+        expect(ThroughModel.count()).toEqual(4);
+        expect(ReferencedModel.withId(1).reverseManyField.count()).toEqual(2);
+    });
+});


### PR DESCRIPTION
Implementation of #265.

Adds an option to provide `Model` class as a first argument to `oneToOne`, `fk` and `many` or as `to` / `through` properties of  `oneToOne`, `fk` and `many` overloads accepting an object argument.