### PR TITLE
Reduce accessedModelInstances, fullTableScannedModels and accessedIndexes computation complexity

### DIFF
--- a/src/Session.js
+++ b/src/Session.js
@@ -49,6 +49,10 @@ const Session = class Session {
         return this.modelData[modelName];
     }
 
+    getModelData() {
+        return this.modelData;
+    }
+
     markAccessed(modelName, modelIds) {
         const data = this.getDataForModel(modelName);
         if (!data.accessedInstances) {
@@ -60,13 +64,12 @@ const Session = class Session {
     }
 
     get accessedModelInstances() {
-        return this.sessionBoundModels
-            .filter(({ modelName }) => this.getDataForModel(modelName).accessedInstances)
-            .reduce(
-                (result, { modelName }) => ({
-                    ...result,
-                    [modelName]: this.getDataForModel(modelName).accessedInstances,
-                }), {});
+        return Object.entries(this.getModelData()).reduce((result, [key, value]) => {
+            if (value.accessedInstances) {
+                result[key] = value.accessedInstances;
+            }
+            return result;
+        }, {});
     }
 
     markFullTableScanned(modelName) {
@@ -75,9 +78,12 @@ const Session = class Session {
     }
 
     get fullTableScannedModels() {
-        return this.sessionBoundModels
-            .filter(({ modelName }) => this.getDataForModel(modelName).fullTableScanned)
-            .map(({ modelName }) => modelName);
+        return Object.entries(this.getModelData()).reduce((result, [key, value]) => {
+            if (value.fullTableScanned) {
+                result.push(key);
+            }
+            return result;
+        }, []);
     }
 
     markAccessedIndexes(indexes) {
@@ -94,12 +100,12 @@ const Session = class Session {
     }
 
     get accessedIndexes() {
-        return this.sessionBoundModels
-            .filter(({ modelName }) => this.getDataForModel(modelName).accessedIndexes)
-            .reduce((result, { modelName }) => ({
-                ...result,
-                [modelName]: this.getDataForModel(modelName).accessedIndexes,
-            }), {});
+        return Object.entries(this.getModelData()).reduce((result, [key, value]) => {
+            if (value.accessedIndexes) {
+                result[key] = value.accessedIndexes;
+            }
+            return result;
+        }, {});
     }
 
     /**


### PR DESCRIPTION
-  Iterate on `modelData` Instead of `sessionBoundModels` to keep performance consistent even with a lot of models
- single iteration with reduce instead of chained filter/map/reduce
- got rid of reduce ({...spread}) https://www.richsnapp.com/blog/2019/06-09-reduce-spread-anti-pattern
