### PR TITLE
Update re-reselect call to use new api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12642,9 +12642,9 @@
       }
     },
     "re-reselect": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/re-reselect/-/re-reselect-3.1.0.tgz",
-      "integrity": "sha512-1Dh/EKWarO/SeXZCodZBT2puHZRuZUCngCueisCfggCIg+yldyk/N1PTpCkJW+jiWJX4qJFc6ip5l8wDBRsyaQ=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/re-reselect/-/re-reselect-3.4.0.tgz",
+      "integrity": "sha512-JsecfN+JlckncVXTWFWjn0Vk6uInl8GSf4eEd9tTk5qXHlgqkPdILpnYpgZcISXNYAzvfvsCZviaDk8AxyS5sg=="
     },
     "react-is": {
       "version": "16.8.6",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@babel/runtime": "^7.0.0",
     "immutable-ops": "^0.7.0",
     "lodash": "^4.17.11",
-    "re-reselect": "^3.1.0",
+    "re-reselect": "^3.4.0",
     "reselect": "^3.0.1"
   }
 }

--- a/src/redux.js
+++ b/src/redux.js
@@ -48,7 +48,8 @@ function createSelectorFromSpec(spec) {
     return createCachedSelector(
         spec.dependencies,
         spec.resultFunc
-    )(spec.keySelector, {
+    )({
+        keySelector: spec.keySelector,
         cacheObject: new FlatMapCache(),
         selectorCreator: createSelector, // eslint-disable-line no-use-before-define
     });


### PR DESCRIPTION
This PR upgrades `re-reselect` dependency to version`^3.4.0` and updates `createCachedSelector` initialisation call to use the single argument API, which is the [only one supported long term](https://github.com/toomuchdesign/re-reselect/blob/master/CHANGELOG.md#340).

PS. I'm the maintainer of `re-reselect` :).

* [X] Make sure you propose PR to correct branch: hotfix for `master`, feature for latest active branch `feature/x`.
* [X] Run `npm run lint` and fix those errors before submitting in order to keep consistent code style.
* [X] Rebase before creating a PR to keep commit history clear.
* [X] Add some descriptions and refer relative issues for you PR.
