### PR TITLE
M2m accessors

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,11 +471,28 @@ Book.fields = {
 }
 ```
 
-All the fields `fk`, `oneToOne` and `many` take a single argument, the related model name. The fields will be available as properties on each `Model` instance. You can set related fields with the id value of the related instance, or the related instance itself.
+All the fields `fk`, `oneToOne` and `many` accept a single argument, the related model name. The fields will be available as properties on each `Model` instance. You can set related fields with the id value of the related instance, or the related instance itself.
 
 For `fk`, you can access the reverse relation through `author.bookSet`, where the related name is `${modelName}Set`. Same goes for `many`. For `oneToOne`, the reverse relation can be accessed by just the model name the field was declared on: `author.book`.
 
 For `many` field declarations, accessing the field on a Model instance will return a `QuerySet` with two additional methods: `add` and `remove`. They take 1 or more arguments, where the arguments are either Model instances or their id's. Calling these methods records updates that will be reflected in the next state.
+
+Relations support more configuration options like accessors, related names, etc. by passing an object:
+
+```javascript
+class Book extends Model {
+    static get fields() {
+        return {
+            id: attr(),
+            name: attr(),
+            author_id: fk({ to: 'Author', as: 'author', relatedName: 'writtenBooks' }),
+            reviewers_id: many({ to: 'Author', as: 'reviewers', relatedName: 'reviewedBooks' })
+        };
+    }
+}
+```
+
+See [fk](https://redux-orm.github.io/redux-orm/global.html#fk), [oneToOne](https://redux-orm.github.io/redux-orm/global.html#oneToOne), and [many](https://redux-orm.github.io/redux-orm/global.html#many) in the documentation for more information.
 
 When declaring model classes, always remember to set the `modelName` property. It needs to be set explicitly, because running your code through a mangler would otherwise break functionality. The `modelName` will be used to resolve all related fields.
 

--- a/src/Model.js
+++ b/src/Model.js
@@ -289,10 +289,19 @@ const Model = class Model {
                     props[key] = field.getDefault();
                 }
             } else if (valuePassed) {
-                // If a value is supplied for a ManyToMany field,
-                // discard them from props and save for later processing.
+                // Save for later processing
                 m2mRelations[key] = userProps[key];
-                delete props[key];
+
+                if (!field.as) {
+                    /**
+                     * The relationship does not have an accessor
+                     * Discard the value from props as the field will be populated later with instances
+                     * from the target models when refreshing the M2M relations.
+                     * If the relationship does have an accessor (`as`) field then we do want to keep this
+                     * original value in the props to expose the raw list of IDs from the instance.
+                     */
+                    delete props[key];
+                }
             }
         });
 
@@ -574,7 +583,17 @@ const Model = class Model {
                 } else if (field instanceof ManyToMany) {
                     // field is forward relation
                     m2mRelations[mergeKey] = mergeObj[mergeKey];
-                    delete mergeObj[mergeKey];
+
+                    if (!field.as) {
+                        /**
+                         * The relationship does not have an accessor
+                         * Discard the value from props as the field will be populated later with instances
+                         * from the target models when refreshing the M2M relations.
+                         * If the relationship does have an accessor (`as`) field then we do want to keep this
+                         * original value in the props to expose the raw list of IDs from the instance.
+                         */
+                        delete mergeObj[mergeKey];
+                    }
                 }
             } else if (virtualFields.hasOwnProperty(mergeKey)) {
                 const field = virtualFields[mergeKey];
@@ -686,10 +705,11 @@ const Model = class Model {
                     add: idsToAdd,
                 } = diffActions;
                 if (idsToDelete.length > 0) {
-                    this[name].remove(...idsToDelete);
+                    this[field.as || name].remove(...idsToDelete);
                 }
+
                 if (idsToAdd.length > 0) {
-                    this[name].add(...idsToAdd);
+                    this[field.as || name].add(...idsToAdd);
                 }
             }
         });

--- a/src/fields.js
+++ b/src/fields.js
@@ -364,6 +364,7 @@ export class ManyToMany extends RelationalField {
             relatedName: fieldName,
             through: this.through,
             throughFields: this.getThroughFields(fieldName, model, toModel, throughModel),
+            as: this.as,
         });
     }
 

--- a/src/test/functional/many2many.js
+++ b/src/test/functional/many2many.js
@@ -598,4 +598,33 @@ describe('Many to many relationships', () => {
             validateRelationState();
         });
     });
+
+    describe('many-many with accessor', () => {
+        it('registers relationship with an accessor', () => {
+            const User = class extends Model {};
+            User.modelName = 'User';
+            User.fields = {
+                id: attr(),
+                projects_id: many({ to: 'Project', relatedName: 'users', as: 'projects' }),
+            };
+
+            const Project = class extends Model {};
+            Project.modelName = 'Project';
+            Project.fields = {
+                id: attr(),
+            };
+
+            orm = new ORM();
+            orm.register(User, Project);
+            session = orm.session();
+
+            session.Project.create({ id: 'p0' });
+            session.Project.create({ id: 'p1' });
+            session.User.create({ id: 'u0', projects_id: ['p0', 'p1'] });
+
+            const u0 = session.User.withId('u0');
+            expect(u0.projects_id).toEqual(['p0', 'p1']);
+            expect(u0.projects.toRefArray()).toEqual([{ id: 'p0' }, { id: 'p1' }]);
+        });
+    });
 });


### PR DESCRIPTION
This PR for #232 allows using an accessor (`as`) when defining a many-to-many relationship while keeping the value in the original field to behave the same as `ForeignKey` with `as`.

Example definition:
```js
User.fields = {
    id: attr(),
    projects_id: many({ to: 'Project', relatedName: 'users', as: 'projects' }),
};
```

which allows accessing the related projects with:

```js
session.User.create({ id: 'u0', projects_id: ['p0', 'p1'] });

session.User.withId('u0').projects // QuerySet<Project>
session.User.withId('u0').projects_id // Array of IDs (['p0', 'p1'])
```

----

The PR contains the following modifications:

- Pass `as` to the virtual field of the M2M relationship so that we can populate the right field when refreshing the M2M values
- Update the QuerySet on the field named `as` instead of the original field name if configured
- Keep the original field from props as is in `create`/`update` when an accessor is configured
- Update to the README to add an example of a `fk` and `many` with an accessor
