### PR TITLE
Use `Symbol.for` to create symbols in the global symbol registry

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -9,9 +9,9 @@ export const ORDER_BY = 'REDUX_ORM_ORDER_BY';
 export const SUCCESS = 'SUCCESS';
 export const FAILURE = 'FAILURE';
 
-export const STATE_FLAG = Symbol('REDUX_ORM_STATE_FLAG');
+export const STATE_FLAG = Symbol.for('REDUX_ORM_STATE_FLAG');
 
-export const ALL_INSTANCES = Symbol('REDUX_ORM_ALL_INSTANCES');
+export const ALL_INSTANCES = Symbol.for('REDUX_ORM_ALL_INSTANCES');
 
 export const ID_ARG_KEY_SELECTOR = (state, idArg) => (
     (typeof idArg === 'undefined') ? ALL_INSTANCES : idArg

--- a/src/redux.js
+++ b/src/redux.js
@@ -75,7 +75,7 @@ function toORM(arg) { /* eslint-disable no-underscore-dangle */
 }
 
 const selectorCache = new Map();
-const SELECTOR_KEY = Symbol('REDUX_ORM_SELECTOR');
+const SELECTOR_KEY = Symbol.for('REDUX_ORM_SELECTOR');
 
 /**
  * @private


### PR DESCRIPTION
Prior to this change, when using redux-orm across JavaScript contexts (such as iframes and secondary windows), each context will have a unique reference for of the symbol for a key. This was leading to failed symbol checks.

One specific use case this change supports is as follows -
1. Use redux-orm in a browser window to create ORM state.
2. Create a selector using an ORM instance as a parameter In a secondary window with its own copy of redux-orm.
3. Run that selector, passing in the state reference from the primary window.

Without Symbol.for, the [`isOrmState` check in memoize.js](https://github.com/redux-orm/redux-orm/blob/v0.14.0/src/memoize.js#L9) fails, resulting in the selector's result function receiving the ORM state instead of the session instance.
