### PR TITLE
Make STATE_FLAG a string to fix serlialization.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -9,7 +9,7 @@ export const ORDER_BY = "REDUX_ORM_ORDER_BY";
 export const SUCCESS = "SUCCESS";
 export const FAILURE = "FAILURE";
 
-export const STATE_FLAG = Symbol.for("REDUX_ORM_STATE_FLAG");
+export const STATE_FLAG = "REDUX_ORM_STATE_FLAG";
 
 export const ALL_INSTANCES = Symbol.for("REDUX_ORM_ALL_INSTANCES");
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,9 +9,10 @@ export const ORDER_BY = "REDUX_ORM_ORDER_BY";
 export const SUCCESS = "SUCCESS";
 export const FAILURE = "FAILURE";
 
-export const STATE_FLAG = "REDUX_ORM_STATE_FLAG";
+// for detecting ORM state objects
+export const STATE_FLAG = "@@_______REDUX_ORM_STATE_FLAG";
 
-export const ALL_INSTANCES = Symbol.for("REDUX_ORM_ALL_INSTANCES");
-
-export const ID_ARG_KEY_SELECTOR = (state, idArg) =>
+// for caching selectors based on their ID argument
+export const ALL_INSTANCES = Symbol("REDUX_ORM_ALL_INSTANCES");
+export const ID_ARG_KEY_SELECTOR = (_state, idArg) =>
     typeof idArg === "undefined" ? ALL_INSTANCES : idArg;

--- a/src/db/Database.js
+++ b/src/db/Database.js
@@ -7,7 +7,7 @@ import Table from "./Table";
 const BASE_EMPTY_STATE = {};
 Object.defineProperty(BASE_EMPTY_STATE, STATE_FLAG, {
     enumerable: true,
-    value: STATE_FLAG,
+    value: true,
 });
 
 /** @private */

--- a/src/test/functional/serialization.js
+++ b/src/test/functional/serialization.js
@@ -1,15 +1,16 @@
 import { createTestORM } from "../helpers";
 
 let orm;
+let emptyState;
 
 beforeEach(() => {
     orm = createTestORM();
+    emptyState = orm.getEmptyState();
 });
 
-it("can serialize and deserialized the state", () => {
-    const initialState = orm.getEmptyState();
-    const serializedState = JSON.stringify(initialState);
+it("can serialize and deserialize the state", () => {
+    const serializedState = JSON.stringify(emptyState);
     const deserializedState = JSON.parse(serializedState);
 
-    expect(initialState).toEqual(deserializedState);
+    expect(emptyState).toStrictEqual(deserializedState);
 });

--- a/src/test/functional/serialization.js
+++ b/src/test/functional/serialization.js
@@ -1,0 +1,15 @@
+import { createTestORM } from "../helpers";
+
+let orm;
+
+beforeEach(() => {
+    orm = createTestORM();
+});
+
+it("can serialize and deserialized the state", () => {
+    const initialState = orm.getEmptyState();
+    const serializedState = JSON.stringify(initialState);
+    const deserializedState = JSON.parse(serializedState);
+
+    expect(initialState).toEqual(deserializedState);
+});

--- a/src/test/integration/reduxPersist.js
+++ b/src/test/integration/reduxPersist.js
@@ -94,15 +94,15 @@ describe("Redux Persist integration", () => {
     it("creates correct empty state by default", async () => {
         await new Promise(resolve => {
             const store = createStore(createPersistedReducer());
-            const persistor = persistStore(store, null, async () => {
+            persistStore(store, null, async () => {
                 expect(store.getState().orm).toStrictEqual(emptyState);
-            });
 
-            const store2 = createStore(createPersistedReducer());
-            const persistor2 = persistStore(store2);
-            persistor2.subscribe(() => {
-                expect(store2.getState().orm).toStrictEqual(emptyState);
-                resolve();
+                const store2 = createStore(createPersistedReducer());
+                const persistor2 = persistStore(store2);
+                persistor2.subscribe(() => {
+                    expect(store2.getState().orm).toStrictEqual(emptyState);
+                    resolve();
+                });
             });
         });
     });

--- a/src/test/unit/Database.js
+++ b/src/test/unit/Database.js
@@ -27,7 +27,7 @@ describe("createDatabase", () => {
 
     it("getEmptyState", () => {
         expect(emptyState).toEqual({
-            [STATE_FLAG]: STATE_FLAG,
+            [STATE_FLAG]: true,
             Book: {
                 indexes: {},
                 items: [],
@@ -74,7 +74,7 @@ describe("createDatabase", () => {
         expect(payload).toBe(props);
         expect(state).not.toBe(emptyState);
         expect(state).toEqual({
-            [STATE_FLAG]: STATE_FLAG,
+            [STATE_FLAG]: true,
             Book: {
                 items: [0],
                 itemsById: {
@@ -111,7 +111,7 @@ describe("createDatabase", () => {
         expect(payload).toEqual({ id: 0, name: "Example Book" });
         expect(state).not.toBe(emptyState);
         expect(state).toEqual({
-            [STATE_FLAG]: STATE_FLAG,
+            [STATE_FLAG]: true,
             Book: {
                 items: [0],
                 itemsById: {
@@ -151,7 +151,7 @@ describe("createDatabase", () => {
         expect(payload2).toEqual({ id: 1, name: "Example Book Two" });
         expect(state2).toBe(state);
         expect(state2).toEqual({
-            [STATE_FLAG]: STATE_FLAG,
+            [STATE_FLAG]: true,
             Book: {
                 items: [0, 1],
                 itemsById: {

--- a/src/test/unit/ORM.js
+++ b/src/test/unit/ORM.js
@@ -192,7 +192,7 @@ describe("ORM", () => {
             const defaultState = orm.getEmptyState();
 
             expect(defaultState).toEqual({
-                [STATE_FLAG]: STATE_FLAG,
+                [STATE_FLAG]: true,
                 Book: {
                     items: [],
                     itemsById: {},


### PR DESCRIPTION
Resolves https://github.com/redux-orm/redux-orm/issues/320

JS symbols aren't serializable, so we should use a string for the
`STATE_FLAG` in the orm state.
